### PR TITLE
[codex] add Flue-style Pi sandbox harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The important boundary is simple:
 - JSON-RPC 2.0 bridge over stdio with `Content-Length` framing
 - TypeScript SDK in
   [`packages/camlflow-ts-json-rpc-sdk`](./packages/camlflow-ts-json-rpc-sdk)
-- Pi host adapter SDK in
+- Pi host adapter SDK and Flue-style sandbox harness in
   [`packages/camlflow-pi-sdk`](./packages/camlflow-pi-sdk)
 - editor support in
   [`packages/camlflow-vscode`](./packages/camlflow-vscode) and
@@ -294,6 +294,14 @@ It wraps `camlflow-ts-json-rpc-sdk`, declares
 `@mariozechner/pi-coding-agent` as a peer dependency, and exposes a typed
 `createPiCamlFlowHostSession(...).runWorkflow(...)` API for native Pi command,
 palette, or UI surfaces.
+
+It also exposes a programmable harness shaped around
+`createPiCamlFlowHarness(...).init({ sandbox, model })`,
+`agent.session(id?)`, and `session.prompt/skill/task/shell`. Supported sandbox
+presets are `local` / `workspace-write`, `read-only`, `ephemeral`, and custom
+host-owned configs or factories. `session.shell(...)` runs as trusted host code,
+so secrets can be passed through explicit environment variables without placing
+them in model-visible prompts.
 
 The package does not parse `/camlflow-run`. Existing slash-command launcher
 docs and scripts are historical/manual validation scaffolding for the old

--- a/docs/adr/0001-programmatic-camlflow-pi-sdk.md
+++ b/docs/adr/0001-programmatic-camlflow-pi-sdk.md
@@ -19,6 +19,92 @@ The package wraps `camlflow-ts-json-rpc-sdk`, depends on the Pi SDK surface from
 `@mariozechner/pi-coding-agent`, and leaves command, command-palette, file
 action, and other UI registration to `pi-mono`.
 
+The package also exposes a Flue-style agent harness API on top of Pi:
+`createPiCamlFlowHarness(...).init({ sandbox, model })`,
+`agent.session(id?)`, and `session.prompt/skill/task/shell`. This API is
+host-side orchestration sugar around Pi sessions and the existing CamlFlow
+JSON-RPC bridge; it does not change CamlFlow syntax or JSON-RPC method names.
+The shared runtime object is validated up front, including `cwd`, `session`,
+`session.thinkingLevel`, `services`, optional `services.agentDir`, and the
+required model registry methods, so bad host wiring fails before worker sessions
+or JSON-RPC clients are created. The model registry's
+available-model lookup must return an array of Pi model objects, model lookups
+must return the same NUL-free string shape, and auth checks must return booleans. Exported
+option bags, callbacks, injected factory functions, worker sessions, and
+JSON-RPC clients are shape-checked before the adapter calls prompt, initialize,
+or run. The latest assistant-role message from injected worker sessions is
+authoritative and must contain shaped text content before results are parsed;
+malformed latest output is rejected instead of falling back to older assistant
+text. Streamed `text_delta` events must carry string deltas. Assistant
+`stopReason` and `errorMessage` status fields must be strings when present.
+Worker `subscribe(...)` calls must return an unsubscribe function before
+prompting starts. Harness result parser option shapes are validated before a
+prompt is sent, avoiding Pi side effects for malformed host parser wiring.
+Injected JSON-RPC client
+`initialize` and `run` results are validated before they are exposed through the
+harness, including protocol/IR versions,
+boolean capabilities, effect kinds, run id, step count, and strict JSON workflow
+result objects and output. `camlflow` spawn overrides are validated before use
+so malformed commands, args, cwd, env, stderr, or callback overrides do not
+reach the JSON-RPC process launcher. Trace, diagnostic, progress, and
+output-chunk notifications are validated as strict JSON-RPC payloads before host
+callbacks run. Inbound `executeEffect` request envelopes are validated before
+they are mapped into Pi worker prompts, including string/integer request ids,
+strict JSON params, run metadata, known effect kinds, kind/role pairing, inline
+agent definition metadata, and effect request fields. Inline definitions are
+accepted only for `inline-agent` effects and are required for that effect kind.
+The validated JSON-RPC request `params` are the source of truth, and the
+effect-handler context must provide `emitOutputChunk` before any worker session
+is created.
+
+Sandbox support is represented as host-owned presets and custom configs:
+`local` / `workspace-write`, `read-only`, `ephemeral`, or `{ kind, cwd, tools,
+shell, dispose }`. Hosts may also pass a sandbox factory that lazily returns
+one of those configs for an initialized agent; factories must return an explicit
+preset, config, or custom sandbox rather than relying on fallback defaults. The
+sandbox chooses the Pi tools available to model turns, while
+`session.shell(...)` remains trusted host code for explicit commands and
+environment variables. Built-in local shell sandboxes validate `cwd` after
+filesystem symlink resolution.
+Unknown sandbox kinds are rejected at runtime, and custom sandboxes must provide
+their own `tools` list or factory. Automatic directory cleanup and the
+`cleanup` flag are limited to `ephemeral` sandboxes; custom or host-owned
+sandboxes use `dispose` for cleanup.
+
+An initialized harness agent owns one sandbox. Sessions share that sandbox,
+`agent.runWorkflow(...)` reuses it for CamlFlow effect workers, and
+`agent.close()` cancels active workflow runs and releases it. `session.close()`
+only closes the Pi conversation. Prompt and skill calls are serial per session;
+hosts can open multiple sessions or use `session.task(...)` for independent
+concurrent work. Skill names are validated against Pi's lowercase
+letter/digit/hyphen naming rules before a `/skill:name` command is generated.
+Prompt and task text must be non-empty after trimming.
+Agent `cwd`, `id`, and string `model` overrides are validated before agent
+creation; named models must resolve through the runtime model registry.
+Workflow paths must also be non-empty, and pre-aborted workflow signals reject
+before the JSON-RPC client is spawned. `entrypoint`, `skillsDir`, and
+`includePaths` entries must be non-empty when provided. Runtime option objects
+are validated at public API boundaries, including prompt/task/skill options,
+trusted shell fields, cancellation signals, and optional effect request metadata.
+Effect `outputSchema` must be a strict JSON object. Workflow input, effect
+input, and skill args must be strict JSON values; JavaScript-only values such as
+`undefined`, functions, symbols, bigint values,
+circular references, non-finite numbers, sparse arrays, and non-plain objects
+are rejected before the adapter spawns or prompts anything. Hidden properties,
+symbol keys, `toJSON` rewrites, and array side properties are also rejected
+because JSON would silently omit or rewrite them.
+Trusted shell command, cwd, stdin, and env strings reject embedded NUL bytes;
+env maps must be plain enumerable objects, and env names must also be non-empty
+and must not contain `=`. Custom shell results must use a non-negative integer or
+null `code`, a non-empty NUL-free string or null `signal`, and string
+stdout/stderr values. Runtime cwd, sandbox cwd, workflow paths, include paths,
+and effect control strings such as effect name, kind, declared return type,
+directory, and run id also reject embedded NUL bytes before filesystem, spawn,
+prompt, or stream-id APIs see them.
+Host sessions auto-shutdown the JSON-RPC client after runs by default; shutdown
+failures are reported after otherwise successful runs and suppressed when a
+primary run failure or explicit cancellation already occurred.
+
 The package does not parse or expose `/camlflow-run`.
 
 ## Consequences
@@ -26,7 +112,11 @@ The package does not parse or expose `/camlflow-run`.
 - CamlFlow owns the reusable orchestration adapter and JSON-RPC bridge wiring.
 - Pi owns model selection, tools, auth, worker sessions, cancellation UI, and
   user-facing command surfaces.
+- Host harness code owns sandbox selection, trusted shell execution, and secret
+  injection boundaries.
 - Each CamlFlow effect maps to a fresh in-memory Pi worker session.
+- Effect cancellation during worker creation aborts and disposes the late worker
+  before any prompt is sent.
 - Final effect success is still the existing JSON-RPC effect response carrying
   parsed JSON, not advisory streamed text.
 - The JSON-RPC protocol version, method names, notifications, and framing remain

--- a/docs/how-to-run-and-install.md
+++ b/docs/how-to-run-and-install.md
@@ -220,10 +220,21 @@ npm install
 npm test
 ```
 
-This package wraps the JSON-RPC SDK and exposes
-`createPiCamlFlowHostSession(...).runWorkflow(...)` for native Pi command,
-palette, or panel code. It intentionally does not parse `/camlflow-run`; Pi UI
-registration remains in `pi-mono`.
+This package wraps the JSON-RPC SDK and exposes two host-side APIs:
+
+- `createPiCamlFlowHostSession(...).runWorkflow(...)` for native Pi command,
+  palette, or panel code
+- `createPiCamlFlowHarness(...).init({ sandbox, model })` for Flue-style
+  `agent.session(...).prompt/skill/task/shell` orchestration
+
+Supported harness sandbox presets are `local` / `workspace-write`,
+`read-only`, `ephemeral`, and custom host-owned configs or factories. The
+package constrains trusted shell `cwd` values to the sandbox root and
+checks built-in local shell paths after symlink resolution. Automatic directory
+removal and the `cleanup` flag are limited to `ephemeral`; use `dispose` for
+custom sandbox cleanup.
+The package intentionally does not parse `/camlflow-run`; Pi UI registration
+remains in `pi-mono`.
 
 Compile-checked host sketches are in
 [`packages/camlflow-pi-sdk/examples`](../packages/camlflow-pi-sdk/examples).

--- a/packages/camlflow-pi-sdk/README.md
+++ b/packages/camlflow-pi-sdk/README.md
@@ -1,11 +1,27 @@
 # camlflow-pi-sdk
 
-Programmatic Pi adapter for CamlFlow workflows.
+Programmatic Pi adapter and sandbox-aware agent harness for CamlFlow workflows.
 
 This package wraps `camlflow-ts-json-rpc-sdk` and maps each
 `camlflow/executeEffect` request onto an ephemeral in-memory Pi worker session.
 It intentionally does not register or parse `/camlflow-run`; command palettes,
 slash commands, file actions, and other UI entrypoints remain owned by `pi-mono`.
+
+It also exposes a small Flue-style harness API around Pi:
+
+- `createPiCamlFlowHarness(...).init({ sandbox, model })`
+- `agent.session(id?)`
+- `session.prompt(...)`
+- `session.skill(...)`
+- `session.task(...)`
+- `session.shell(...)`
+
+The package root exports the harness, host-session factory, effect executor,
+effect prompt builder, JSON-output parser, and typed error classes. It does not
+export Pi slash-command parsers; skill execution stays behind `session.skill(...)`.
+
+The harness keeps CamlFlow's typed workflow execution and Pi's model/tool
+runtime separate from trusted host orchestration code.
 
 See
 [`docs/adr/0001-programmatic-camlflow-pi-sdk.md`](../../docs/adr/0001-programmatic-camlflow-pi-sdk.md)
@@ -74,6 +90,155 @@ console.log(result.output);
 By default, the adapter starts `camlflow serve --stdio` and talks to it through
 the existing JSON-RPC bridge. Override `camlflow.command`, `camlflow.args`, or
 `camlflow.cwd` when the host needs to spawn a local checkout through Dune.
+The `runtime` object is validated up front: `cwd`, `session`,
+`session.thinkingLevel`, `services`, optional `services.agentDir`, and a
+`modelRegistry` with `getAvailable`, `find`, and `hasConfiguredAuth` methods
+must be present before any worker session or JSON-RPC client is created.
+`modelRegistry.getAvailable()` must return an array of Pi model objects with
+non-empty `provider`, `id`, `name`, and `api` fields, `find(...)` must return the
+same NUL-free string shape, and `hasConfiguredAuth(...)` must return a boolean.
+Exported option bags, callbacks, injected factory functions, and injected `workerSessionFactory`
+/ `clientFactory` results are shape-checked before prompts, `initialize`, or
+`run` are called, so bad host wiring fails at the boundary instead of surfacing
+as a later method error. The latest assistant-role message from injected worker
+sessions is authoritative and must contain shaped text content before results are
+parsed; malformed latest output is rejected instead of falling back to older
+assistant text. Streamed `text_delta` events must carry string deltas. Assistant
+`stopReason` and `errorMessage` status fields must be strings when present.
+Worker `subscribe(...)` calls must return an unsubscribe function before
+prompting starts. Injected JSON-RPC clients must also return shaped `initialize` and `run` results: non-empty protocol/IR versions, object
+boolean capabilities, known effect kinds, a non-empty run id, non-negative step
+count, and strict JSON result objects and workflow output. `camlflow` spawn
+overrides are checked as spawn-safe values too: command/cwd/env/arg strings
+reject NUL bytes, args must be strings, stderr must be `inherit` or `pipe`, and
+callback overrides must be functions.
+Trace, diagnostic, progress, and output-chunk notifications are validated as
+strict JSON-RPC payloads before host callbacks run, so malformed notification
+data fails at the adapter boundary.
+Inbound `executeEffect` request envelopes are also validated before they are
+mapped into Pi worker prompts, including string/integer request ids, strict JSON
+params, run metadata, known effect kinds, kind/role pairing, inline agent
+definition metadata, and effect request fields. Inline definitions are accepted
+only for `inline-agent` effects and are required for that effect kind. The
+adapter uses the validated JSON-RPC request `params` as the source of truth, and
+the effect-handler context must provide `emitOutputChunk` before any worker
+session is created.
+`workflowPath` must be non-empty, and a pre-aborted `signal` rejects before the
+JSON-RPC client is spawned. `entrypoint`, `skillsDir`, and `includePaths`
+entries must also be non-empty when provided. Runtime option objects are checked
+at API boundaries, including prompt/task/skill options, shell `cwd`/`env`/`stdin`
+fields, `AbortSignal`-shaped cancellation inputs, and optional effect request
+metadata fields. Effect `outputSchema` must be a strict JSON object. Workflow
+input, effect input, and skill args must be strict JSON values: no `undefined`,
+functions, symbols, bigint values, circular
+references, non-finite numbers, sparse arrays, or non-plain objects such as
+`Date` and `Map`. Hidden object properties, symbol keys, `toJSON` rewrites, and
+array side properties are also rejected because JSON would silently omit or
+rewrite them. Trusted shell strings reject embedded NUL bytes, and env maps must
+be plain enumerable objects with non-empty names that do not contain `=`. Runtime
+cwd, sandbox cwd, workflow paths, include paths, and effect control strings such
+as effect name, kind, declared return type, directory, and run id reject embedded
+NUL bytes before filesystem, spawn, prompt, or stream-id APIs see them. Sandbox
+factories must resolve to an explicit preset, config, or custom sandbox object;
+malformed or missing factory results are rejected instead of silently falling
+back to `local`.
+
+## Flue-Style Harness
+
+Use `createPiCamlFlowHarness` when host code wants to orchestrate an agent
+directly and optionally call CamlFlow workflows from that same runtime:
+
+```ts
+import { createPiCamlFlowHarness } from "camlflow-pi-sdk";
+
+const harness = createPiCamlFlowHarness({ runtime });
+const agent = await harness.init({
+  id: "triage",
+  sandbox: "local",
+  model: runtime.session.model,
+});
+
+const session = await agent.session("issue-42");
+
+try {
+  const findings = await session.task("Inspect the checkout and list likely risk areas.", {
+    result: "json",
+  });
+  const plan = await session.skill("triage", {
+    args: { issueNumber: 42, findings },
+    result: "json",
+  });
+  const summary = JSON.stringify(plan);
+
+  await session.shell("git add -A && git commit --file -", {
+    stdin: `fix: ${summary}`,
+    env: { GITHUB_TOKEN: process.env.GITHUB_TOKEN },
+  });
+
+  const workflow = await agent.runWorkflow({
+    workflowPath: "examples/repo-triage/main.cml",
+    input: { task: "Summarize the current checkout." },
+  });
+
+  console.log(workflow.output);
+} finally {
+  await session.close();
+  await agent.close();
+}
+```
+
+Supported sandbox presets:
+
+- `local` / `workspace-write`: Pi coding tools plus trusted host shell in the
+  selected working directory.
+- `read-only`: Pi read/search/list tools; `session.shell(...)` is disabled.
+- `ephemeral`: a temporary local workspace with Pi coding tools and shell,
+  removed when the agent closes unless `cleanup: false` is set.
+- custom configs: pass `{ kind, cwd, tools, shell, dispose }` to plug in a
+  host-owned sandbox implementation.
+- sandbox factories: pass `(cwd) => ({ kind, cwd, tools, shell, dispose })` to
+  lazily create a sandbox once per initialized agent.
+Unknown sandbox kinds are rejected at runtime. Custom sandboxes must provide
+their own `tools` list or factory, and sandbox configs validate `cwd`, `tools`,
+`shell`, `cleanup`, and `dispose` before any worker session is created.
+Automatic directory removal and the `cleanup` flag are limited to `ephemeral`;
+use `dispose` for custom cleanup of host-owned sandboxes.
+
+`session.shell(...)` is host-side trusted code. Pass sensitive environment
+variables there instead of placing secrets in prompts or files visible to the
+model. Shell commands must be non-empty, and `timeoutMs` must be a finite
+non-negative number. Custom shell executors must return `{ code, signal,
+stdout, stderr }` with a non-negative integer or null `code`, a non-empty
+NUL-free string or null `signal`, and string stdout/stderr values. Shell `cwd` values are
+resolved inside the sandbox root; attempts to escape that root with `..` or an
+absolute path fail before the command starts. For built-in local shell
+sandboxes, `cwd` is also checked after filesystem symlink resolution.
+
+`prompt(...)` and `skill(...)` return text by default. Pass `result: "json"` to
+parse the final assistant message as JSON, or pass a parser/schema object with
+`parse(value)` or `safeParse(value)` for host-side validation. Parser option
+shapes are checked before the prompt is sent, so malformed parser wiring fails
+without invoking Pi.
+Prompt and task text must be non-empty after trimming.
+
+`session.task(...)` runs a focused one-shot child session with separate message
+history and the same sandbox, then closes that child session after the prompt
+finishes.
+`session.skill(name, ...)` validates Pi skill names before creating a
+`/skill:name` command; names must use lowercase letters, digits, and single
+hyphens. Skill `args` must be JSON-serializable before the Pi prompt is sent.
+
+The initialized `agent` owns sandbox state. Multiple sessions opened from the
+same agent share the same sandbox, and `agent.runWorkflow(...)` executes
+CamlFlow effect workers in that sandbox. Closing an individual session disposes
+the Pi conversation only; closing the agent cancels active workflow runs and
+releases the sandbox. Calling `session.abort()` aborts both the active Pi worker
+turn and any in-flight trusted shell command started from that session.
+Prompt and skill calls are serial per session; open a second session or use
+`session.task(...)` for independent concurrent work.
+Agent `cwd`, `id`, and string `model` overrides are validated before the agent
+is created. Named model overrides use `provider/model` and must resolve through
+the runtime model registry.
 
 ## Effect Execution
 
@@ -81,14 +246,19 @@ For each CamlFlow effect, the adapter:
 
 - creates a fresh Pi worker session with `SessionManager.inMemory()`
 - uses the current Pi model, thinking level, model registry, auth storage, and
-  coding tools
+  sandbox-selected Pi tools
 - sends CamlFlow's rendered effect prompt with a small JSON-only wrapper
 - relays Pi text deltas as `camlflow/outputChunk` notifications
 - parses the final assistant message as JSON and returns it through the existing
   `camlflow/executeEffect` response contract
 
 Abort signals are shared by the CamlFlow run request and the active Pi worker
-session. Calling `host.cancel()` aborts both sides of the current run.
+session. Calling `host.cancel()` aborts both sides of the current run and
+suppresses shutdown errors from the already-cancelled JSON-RPC client.
+Successful workflow runs report auto-shutdown failures unless
+`autoShutdown: false` is set.
+If cancellation lands while a worker session is still being created, the late
+worker is aborted and disposed before any prompt is sent.
 
 ## Local Validation
 

--- a/packages/camlflow-pi-sdk/examples/README.md
+++ b/packages/camlflow-pi-sdk/examples/README.md
@@ -41,6 +41,18 @@ Demonstrates:
 - streaming `camlflow/outputChunk` text into UI state
 - normalizing success, cancellation, and failure states
 
+### Flue-style harness
+
+Source: `examples/flue-style-harness.ts`
+
+Demonstrates:
+
+- initializing a sandbox-aware agent with `createPiCamlFlowHarness`
+- opening a named session and calling `session.skill(...)`
+- running a one-shot detached child session with `session.task(...)`
+- running trusted host shell commands with explicit environment variables
+- invoking a typed CamlFlow workflow from the same agent runtime
+
 ## Validation
 
 `npm test` builds these examples before running the SDK tests, so type drift in

--- a/packages/camlflow-pi-sdk/examples/flue-style-harness.ts
+++ b/packages/camlflow-pi-sdk/examples/flue-style-harness.ts
@@ -1,0 +1,80 @@
+import {
+  createPiCamlFlowHarness,
+  type JsonValue,
+  type PiCamlFlowRuntime,
+  type PiCamlFlowSandboxInput,
+  type PiCamlFlowShellResult,
+  type PiCamlFlowWorkflowRunResult,
+} from "../dist/index.js";
+
+export interface IssueTriagePayload {
+  issueNumber: number;
+  task: string;
+}
+
+export interface IssueTriageResult {
+  triage: JsonValue;
+  comment: string;
+  shell: PiCamlFlowShellResult;
+  workflow: PiCamlFlowWorkflowRunResult;
+}
+
+export const ephemeralSandboxWithDisposeExample = {
+  kind: "ephemeral",
+  dispose: async () => undefined,
+} satisfies PiCamlFlowSandboxInput;
+
+export async function runIssueTriageHarness(
+  runtime: PiCamlFlowRuntime,
+  payload: IssueTriagePayload,
+  env: { GITHUB_TOKEN?: string },
+): Promise<IssueTriageResult> {
+  const harness = createPiCamlFlowHarness({ runtime });
+  const agent = await harness.init({
+    id: `issue-${payload.issueNumber}`,
+    sandbox: "local",
+    model: runtime.session.model,
+  });
+  const session = await agent.session("triage");
+
+  try {
+    const findings = await session.task("Inspect the checkout for likely triage risk areas.", {
+      result: "json",
+    });
+    const triage = await session.skill("triage", {
+      args: {
+        issueNumber: payload.issueNumber,
+        task: payload.task,
+        findings,
+      },
+      result: "json",
+    });
+    const comment = await session.prompt(
+      "Write a concise GitHub issue comment for the triage result.",
+    );
+    const shell = await session.shell("gh issue comment \"$ISSUE\" --body-file -", {
+      stdin: comment,
+      env: {
+        GITHUB_TOKEN: env.GITHUB_TOKEN,
+        ISSUE: String(payload.issueNumber),
+      },
+    });
+    const workflow = await agent.runWorkflow({
+      workflowPath: "examples/repo-triage/main.cml",
+      input: {
+        task: payload.task,
+        suspected_area: "repository",
+        file_hints: [],
+        goals: ["produce a concrete triage report"],
+        constraints: ["ground conclusions in repository evidence"],
+        mode: { tag: "Quick" },
+      },
+      skillsDir: "examples/repo-triage/skills",
+    });
+
+    return { triage, comment, shell, workflow };
+  } finally {
+    await session.close();
+    await agent.close();
+  }
+}

--- a/packages/camlflow-pi-sdk/package.json
+++ b/packages/camlflow-pi-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "camlflow-pi-sdk",
   "version": "0.1.0",
-  "description": "Programmatic Pi SDK adapter for running CamlFlow workflows through the JSON-RPC bridge",
+  "description": "Programmatic Pi SDK adapter and sandbox harness for CamlFlow workflows",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -26,6 +26,8 @@
   "keywords": [
     "camlflow",
     "pi",
+    "agent-harness",
+    "sandbox",
     "json-rpc",
     "sdk"
   ],

--- a/packages/camlflow-pi-sdk/src/index.ts
+++ b/packages/camlflow-pi-sdk/src/index.ts
@@ -1,7 +1,15 @@
+import { spawn } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, relative, resolve } from "node:path";
+
 import {
   createAgentSession,
   createCodingTools,
   createExtensionRuntime,
+  createReadOnlyTools,
+  DefaultResourceLoader,
   SessionManager,
   SettingsManager,
   type AgentSession,
@@ -28,6 +36,20 @@ import type {
 const DEFAULT_ENTRYPOINT = "main";
 const DEFAULT_CAMLFLOW_COMMAND = "camlflow";
 const DEFAULT_CAMLFLOW_ARGS = ["serve", "--stdio"];
+const SANDBOX_PRESETS = new Set(["local", "workspace-write", "read-only", "ephemeral"]);
+const CAMLFLOW_CAPABILITY_NAMES = [
+  "check",
+  "compile",
+  "run",
+  "executeEffect",
+  "trace",
+  "diagnostic",
+  "progress",
+  "streaming",
+  "cancelRequest",
+  "renderedPrompt",
+  "outputSchema",
+] as const;
 const WORKER_SYSTEM_PROMPT = [
   "You are executing one CamlFlow effect inside Pi.",
   "Use tools when needed.",
@@ -40,11 +62,68 @@ type PiModel = NonNullable<CreateAgentSessionOptions["model"]>;
 type PiThinkingLevel = NonNullable<CreateAgentSessionOptions["thinkingLevel"]>;
 type PiAuthStorage = NonNullable<CreateAgentSessionOptions["authStorage"]>;
 type PiModelRegistry = NonNullable<CreateAgentSessionOptions["modelRegistry"]>;
+type PiTool = NonNullable<CreateAgentSessionOptions["tools"]>[number];
 
 export type { JsonObject, JsonValue };
 
+export type PiCamlFlowSandboxPreset =
+  | "local"
+  | "workspace-write"
+  | "read-only"
+  | "ephemeral";
+
+export interface PiCamlFlowShellOptions {
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+  stdin?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+export interface PiCamlFlowShellResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}
+
+export type PiCamlFlowShellExecutor = (
+  command: string,
+  options?: PiCamlFlowShellOptions,
+) => MaybePromise<PiCamlFlowShellResult>;
+
+export interface PiCamlFlowSandboxConfig {
+  kind?: PiCamlFlowSandboxPreset;
+  cwd?: string;
+  tools?: PiTool[] | ((cwd: string) => PiTool[]);
+  shell?: PiCamlFlowShellExecutor | false;
+  cleanup?: boolean;
+  dispose?: () => MaybePromise<void>;
+}
+
+export interface PiCamlFlowCustomSandbox {
+  kind: "custom";
+  cwd?: string;
+  tools: PiTool[] | ((cwd: string) => PiTool[]);
+  shell?: PiCamlFlowShellExecutor;
+  dispose?: () => MaybePromise<void>;
+}
+
+export type PiCamlFlowSandboxFactory = (
+  cwd: string,
+) => MaybePromise<
+  PiCamlFlowSandboxPreset | PiCamlFlowSandboxConfig | PiCamlFlowCustomSandbox
+>;
+
+export type PiCamlFlowSandboxInput =
+  | PiCamlFlowSandboxPreset
+  | PiCamlFlowSandboxConfig
+  | PiCamlFlowCustomSandbox
+  | PiCamlFlowSandboxFactory;
+
 export interface PiCamlFlowRuntime {
   cwd: string;
+  sandbox?: PiCamlFlowSandboxInput;
   session: {
     model?: PiModel;
     thinkingLevel?: PiThinkingLevel;
@@ -152,6 +231,84 @@ export interface PiCamlFlowHostSession {
   close(): Promise<void>;
 }
 
+export type PiCamlFlowResultParser<TOutput> =
+  | "json"
+  | ((value: JsonValue) => TOutput)
+  | {
+      parse(value: JsonValue): TOutput;
+    }
+  | {
+      safeParse(value: JsonValue):
+        | { success: true; output: TOutput; data?: never }
+        | { success: true; data: TOutput; output?: never }
+        | { success: false; issues?: unknown; error?: unknown };
+    };
+
+export interface PiCamlFlowPromptOptions<TOutput = string> {
+  result?: PiCamlFlowResultParser<TOutput>;
+  signal?: AbortSignal;
+}
+
+export interface PiCamlFlowSkillOptions<TOutput = string>
+  extends PiCamlFlowPromptOptions<TOutput> {
+  args?: JsonValue;
+}
+
+export interface PiCamlFlowHarnessShellOptions extends PiCamlFlowShellOptions {}
+
+export interface PiCamlFlowAgentSession {
+  readonly id: string;
+  readonly cwd: string;
+  prompt<TOutput = string>(
+    text: string,
+    options?: PiCamlFlowPromptOptions<TOutput>,
+  ): Promise<TOutput>;
+  skill<TOutput = string>(
+    name: string,
+    options?: PiCamlFlowSkillOptions<TOutput>,
+  ): Promise<TOutput>;
+  task<TOutput = string>(
+    text: string,
+    options?: PiCamlFlowPromptOptions<TOutput>,
+  ): Promise<TOutput>;
+  shell(
+    command: string,
+    options?: PiCamlFlowHarnessShellOptions,
+  ): Promise<PiCamlFlowShellResult>;
+  abort(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export interface PiCamlFlowAgent {
+  readonly id: string;
+  readonly cwd: string;
+  session(threadId?: string): Promise<PiCamlFlowAgentSession>;
+  runWorkflow<TOutput extends JsonValue = JsonValue, TInput extends JsonValue = JsonValue>(
+    options: PiCamlFlowWorkflowRunOptions<TInput>,
+  ): Promise<PiCamlFlowWorkflowRunResult<TOutput>>;
+  close(): Promise<void>;
+}
+
+export interface PiCamlFlowAgentInitOptions {
+  id?: string;
+  cwd?: string;
+  model?: PiModel | string;
+  thinkingLevel?: PiThinkingLevel;
+  sandbox?: PiCamlFlowSandboxInput;
+}
+
+export interface PiCamlFlowHarnessOptions extends PiCamlFlowCallbacks {
+  runtime: PiCamlFlowRuntime;
+  camlflow?: Partial<SpawnCamlFlowClientOptions>;
+  clientFactory?: (options: SpawnCamlFlowClientOptions) => CamlFlowClientLike;
+  workerSessionFactory?: PiCamlFlowWorkerSessionFactory;
+  autoShutdown?: boolean;
+}
+
+export interface PiCamlFlowHarness {
+  init(options?: PiCamlFlowAgentInitOptions): Promise<PiCamlFlowAgent>;
+}
+
 export class PiCamlFlowMissingModelError extends Error {
   constructor(effect: Pick<PiCamlFlowEffectRequest, "kind" | "name">) {
     super(
@@ -175,6 +332,8 @@ export class PiCamlFlowEffectExecutor {
     private readonly runtime: PiCamlFlowRuntime,
     options: PiCamlFlowEffectExecutorOptions = {},
   ) {
+    validateEffectExecutorOptions(options);
+    validatePiCamlFlowRuntime(runtime);
     this.workerSessionFactory = options.workerSessionFactory ?? createDefaultWorkerSession;
   }
 
@@ -182,6 +341,8 @@ export class PiCamlFlowEffectExecutor {
     request: PiCamlFlowEffectRequest,
     options: PiCamlFlowEffectExecutionOptions = {},
   ): Promise<TOutput> {
+    validateEffectRequest(request);
+    validateEffectExecutionOptions(options);
     if (options.signal?.aborted) {
       throw new PiCamlFlowEffectCancelledError(request);
     }
@@ -194,20 +355,37 @@ export class PiCamlFlowEffectExecutor {
       thinkingLevel: this.runtime.session.thinkingLevel,
       runtime: this.runtime,
     });
+    validateWorkerSession(session, "Pi CamlFlow effect worker session");
 
-    const unsubscribe = session.subscribe((event) => {
-      const delta = extractTextDelta(event);
-      if (delta !== undefined) {
-        void options.emitOutputChunk?.(delta, false);
-      }
-    });
-
+    let unsubscribe = (): void => undefined;
     const abortHandler = (): void => {
       void session.abort();
     };
-    options.signal?.addEventListener("abort", abortHandler, { once: true });
 
+    let primaryError: unknown;
     try {
+      if (options.signal?.aborted) {
+        await session.abort();
+        throw new PiCamlFlowEffectCancelledError(request);
+      }
+
+      const unsubscribeCandidate = session.subscribe((event) => {
+        const delta = extractTextDelta(event);
+        if (delta !== undefined) {
+          emitAdvisoryOutputChunk(options, delta);
+        }
+      });
+      if (typeof unsubscribeCandidate !== "function") {
+        throw new Error("Pi CamlFlow effect worker session subscribe must return an unsubscribe function");
+      }
+      unsubscribe = unsubscribeCandidate;
+
+      options.signal?.addEventListener("abort", abortHandler, { once: true });
+      if (options.signal?.aborted) {
+        await session.abort();
+        throw new PiCamlFlowEffectCancelledError(request);
+      }
+
       await session.prompt(buildPiCamlFlowEffectPrompt(request), {
         expandPromptTemplates: false,
         source: "extension",
@@ -217,6 +395,7 @@ export class PiCamlFlowEffectExecutor {
       if (!assistant) {
         throw new Error(`CamlFlow effect produced no assistant message: ${request.kind}:${request.name}`);
       }
+      validateAssistantMessageStatus(assistant);
       if (assistant.stopReason === "aborted") {
         throw new PiCamlFlowEffectCancelledError(request);
       }
@@ -234,12 +413,51 @@ export class PiCamlFlowEffectExecutor {
       }
 
       return parseCamlFlowJsonOutput(outputText) as TOutput;
+    } catch (error) {
+      primaryError = error;
+      throw error;
     } finally {
-      await options.emitOutputChunk?.("", true);
-      options.signal?.removeEventListener("abort", abortHandler);
-      unsubscribe();
-      session.dispose();
+      let cleanupError: unknown;
+      const recordCleanupError = (error: unknown): void => {
+        cleanupError ??= error;
+      };
+
+      try {
+        await options.emitOutputChunk?.("", true);
+      } catch (error) {
+        recordCleanupError(error);
+      }
+      try {
+        options.signal?.removeEventListener("abort", abortHandler);
+      } catch (error) {
+        recordCleanupError(error);
+      }
+      try {
+        unsubscribe();
+      } catch (error) {
+        recordCleanupError(error);
+      }
+      try {
+        session.dispose();
+      } catch (error) {
+        recordCleanupError(error);
+      }
+
+      if (primaryError === undefined && cleanupError !== undefined) {
+        throw cleanupError;
+      }
     }
+  }
+}
+
+function emitAdvisoryOutputChunk(
+  options: PiCamlFlowEffectExecutionOptions,
+  delta: string,
+): void {
+  try {
+    void Promise.resolve(options.emitOutputChunk?.(delta, false)).catch(() => undefined);
+  } catch {
+    // Streaming chunks are advisory; effect success is determined by the final assistant message.
   }
 }
 
@@ -265,21 +483,36 @@ class DefaultPiCamlFlowHostSession implements PiCamlFlowHostSession {
     if (this.activeRun) {
       throw new Error("A CamlFlow workflow is already running in this Pi host session");
     }
+    validateWorkflowRunOptions(options);
+    if (options.signal?.aborted) {
+      throw new PiCamlFlowEffectCancelledError({
+        kind: "workflow",
+        name: options.workflowPath,
+      });
+    }
 
     const controller = new AbortController();
-    const signal = combineAbortSignals([controller.signal, options.signal]);
+    const abortSignal = combineAbortSignals([controller.signal, options.signal]);
     const executor = new PiCamlFlowEffectExecutor(this.options.runtime, {
       workerSessionFactory: this.options.workerSessionFactory,
     });
 
-    const spawnOptions = this.buildSpawnOptions(executor, signal);
+    const spawnOptions = this.buildSpawnOptions(executor, abortSignal.signal);
     const client = this.options.clientFactory
       ? this.options.clientFactory(spawnOptions)
       : CamlFlowRpc.spawnCamlFlowClient(spawnOptions);
+    validateCamlFlowClient(client);
 
     this.activeRun = { controller, client };
 
+    let primaryError: unknown;
     try {
+      if (abortSignal.signal.aborted) {
+        throw new PiCamlFlowEffectCancelledError({
+          kind: "workflow",
+          name: options.workflowPath,
+        });
+      }
       const initialize = await client.initialize(
         {
           notifications: {
@@ -288,8 +521,9 @@ class DefaultPiCamlFlowHostSession implements PiCamlFlowHostSession {
             progress: true,
           },
         },
-        { signal },
+        { signal: abortSignal.signal },
       );
+      validateCamlFlowInitializeResult(initialize);
       const entrypoint = options.entrypoint ?? DEFAULT_ENTRYPOINT;
       const run = await client.run<TOutput, TInput>(
         {
@@ -301,8 +535,9 @@ class DefaultPiCamlFlowHostSession implements PiCamlFlowHostSession {
           entry: entrypoint,
           input: options.input,
         },
-        { signal },
+        { signal: abortSignal.signal },
       );
+      validateCamlFlowRunResult(run);
 
       return {
         ...run,
@@ -311,10 +546,29 @@ class DefaultPiCamlFlowHostSession implements PiCamlFlowHostSession {
         workflowPath: options.workflowPath,
         entrypoint,
       };
+    } catch (error) {
+      primaryError = error;
+      throw error;
     } finally {
+      let cleanupError: unknown;
+      const rememberCleanupError = (error: unknown): void => {
+        cleanupError ??= error;
+      };
+      try {
+        abortSignal.cleanup();
+      } catch (error) {
+        rememberCleanupError(error);
+      }
       this.activeRun = undefined;
       if (this.options.autoShutdown !== false) {
-        await client.shutdownAndExit({ timeoutMs: 2000 }).catch(() => undefined);
+        try {
+          await client.shutdownAndExit({ timeoutMs: 2000 });
+        } catch (error) {
+          rememberCleanupError(error);
+        }
+      }
+      if (primaryError === undefined && cleanupError !== undefined) {
+        throw cleanupError;
       }
     }
   }
@@ -344,10 +598,12 @@ class DefaultPiCamlFlowHostSession implements PiCamlFlowHostSession {
       stderr: "inherit",
       ...this.options.camlflow,
       effectHandler: async (
-        params: CamlFlowExecuteEffectParams,
-        _request: JsonRpcRequest<CamlFlowExecuteEffectParams>,
+        _params: CamlFlowExecuteEffectParams,
+        request: JsonRpcRequest<CamlFlowExecuteEffectParams>,
         context: CamlFlowEffectHandlerContext,
       ) => {
+        validateEffectHandlerContext(context);
+        const params = validateExecuteEffectRequest(request);
         const output = await executor.executeEffect(paramsToEffectRequest(params), {
           signal,
           emitOutputChunk: async (delta, done) => {
@@ -361,10 +617,10 @@ class DefaultPiCamlFlowHostSession implements PiCamlFlowHostSession {
         });
         return CamlFlowRpc.effectOutput(output);
       },
-      onTrace: this.options.onTrace,
-      onDiagnostic: this.options.onDiagnostic,
-      onProgress: this.options.onProgress,
-      onOutputChunk: this.options.onOutputChunk,
+      onTrace: wrapTraceCallback(this.options.onTrace),
+      onDiagnostic: wrapDiagnosticCallback(this.options.onDiagnostic),
+      onProgress: wrapProgressCallback(this.options.onProgress),
+      onOutputChunk: wrapOutputChunkCallback(this.options.onOutputChunk),
       onTransportError: this.options.onTransportError,
     };
   }
@@ -373,10 +629,58 @@ class DefaultPiCamlFlowHostSession implements PiCamlFlowHostSession {
 export function createPiCamlFlowHostSession(
   options: PiCamlFlowHostSessionOptions,
 ): PiCamlFlowHostSession {
+  validateHostSessionOptions(options);
+  validatePiCamlFlowRuntime(options.runtime);
   return new DefaultPiCamlFlowHostSession(options);
 }
 
+export function createPiCamlFlowHarness(options: PiCamlFlowHarnessOptions): PiCamlFlowHarness {
+  validateHarnessOptions(options);
+  validatePiCamlFlowRuntime(options.runtime);
+  return {
+    async init(initOptions: PiCamlFlowAgentInitOptions = {}) {
+      validateAgentInitOptions(initOptions);
+      const cwd = initOptions.cwd ?? options.runtime.cwd;
+      const sandboxInput =
+        Object.prototype.hasOwnProperty.call(initOptions, "sandbox")
+          ? initOptions.sandbox
+          : options.runtime.sandbox === undefined
+            ? "local"
+            : options.runtime.sandbox;
+      const model =
+        typeof initOptions.model === "string"
+          ? resolveNamedModel(options.runtime, initOptions.model)
+          : initOptions.model ?? options.runtime.session.model;
+      const thinkingLevel = initOptions.thinkingLevel ?? options.runtime.session.thinkingLevel;
+      const agentId = initOptions.id ?? "default";
+      const agentRuntime: PiCamlFlowRuntime = {
+        ...options.runtime,
+        cwd,
+        sandbox: sandboxInput,
+        session: {
+          ...options.runtime.session,
+          ...(model ? { model } : {}),
+          ...(thinkingLevel ? { thinkingLevel } : {}),
+        },
+      };
+
+      return new DefaultPiCamlFlowAgent(agentId, agentRuntime, {
+        camlflow: options.camlflow,
+        clientFactory: options.clientFactory,
+        workerSessionFactory: options.workerSessionFactory,
+        autoShutdown: options.autoShutdown,
+        onTrace: options.onTrace,
+        onDiagnostic: options.onDiagnostic,
+        onProgress: options.onProgress,
+        onOutputChunk: options.onOutputChunk,
+        onTransportError: options.onTransportError,
+      });
+    },
+  };
+}
+
 export function buildPiCamlFlowEffectPrompt(request: PiCamlFlowEffectRequest): string {
+  validateEffectRequest(request);
   const parts = [
     `Execute the CamlFlow effect ${request.kind}:${request.name}.`,
     "",
@@ -394,7 +698,7 @@ export function buildPiCamlFlowEffectPrompt(request: PiCamlFlowEffectRequest): s
 
   if (request.outputSchema) {
     parts.push("Output schema:");
-    parts.push(JSON.stringify(request.outputSchema, null, 2));
+    parts.push(stringifyPromptJson(request.outputSchema, "CamlFlow effect outputSchema"));
   }
 
   parts.push("", "Rendered CamlFlow prompt:", request.renderedPrompt);
@@ -402,6 +706,9 @@ export function buildPiCamlFlowEffectPrompt(request: PiCamlFlowEffectRequest): s
 }
 
 export function unwrapJsonCodeFence(text: string): string {
+  if (typeof text !== "string") {
+    throw new Error("CamlFlow JSON output must be a string");
+  }
   const trimmed = text.trim();
   const exactFence = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
   if (exactFence) {
@@ -423,6 +730,452 @@ export function parseCamlFlowJsonOutput(text: string): JsonValue {
   }
 }
 
+class DefaultPiCamlFlowAgent implements PiCamlFlowAgent {
+  private sandboxPromise: Promise<ResolvedPiCamlFlowSandbox> | undefined;
+  private readonly sessions = new Set<DefaultPiCamlFlowAgentSession>();
+  private readonly activeHosts = new Set<PiCamlFlowHostSession>();
+  private taskIndex = 0;
+  private closed = false;
+
+  constructor(
+    readonly id: string,
+    private readonly runtime: PiCamlFlowRuntime,
+    private readonly options: Omit<PiCamlFlowHarnessOptions, "runtime">,
+  ) {}
+
+  get cwd(): string {
+    return this.runtime.cwd;
+  }
+
+  async session(threadId = "default"): Promise<PiCamlFlowAgentSession> {
+    validateNonEmptyString(threadId, "Pi CamlFlow session id");
+    const sandbox = await this.getSandbox();
+    this.assertOpen();
+    const model = resolveWorkerModel(this.runtime, {
+      kind: "harness-session",
+      name: `${this.id}:${threadId}`,
+      requestedModel: null,
+    });
+    const workerSession = this.options.workerSessionFactory
+      ? await this.options.workerSessionFactory(
+          {
+            kind: "harness-session",
+            role: "agent",
+            name: `${this.id}:${threadId}`,
+            input: {},
+            renderedPrompt: "",
+            workingDirectory: sandbox.cwd,
+            requestedModel: null,
+          },
+          {
+            cwd: sandbox.cwd,
+            model,
+            thinkingLevel: this.runtime.session.thinkingLevel,
+            runtime: this.runtime,
+          },
+        )
+      : await createHarnessWorkerSession(this.runtime, {
+          cwd: sandbox.cwd,
+          model,
+          thinkingLevel: this.runtime.session.thinkingLevel,
+          sandbox,
+        });
+    validateWorkerSession(workerSession, "Pi CamlFlow harness worker session");
+    if (this.closed) {
+      try {
+        workerSession.dispose();
+      } catch {
+        // The caller needs the lifecycle result; cleanup failures are reported by agent.close().
+      }
+      throw new Error(`Pi CamlFlow agent is closed: ${this.id}`);
+    }
+
+    const session = new DefaultPiCamlFlowAgentSession(
+      `${this.id}:${threadId}`,
+      sandbox,
+      workerSession,
+      {
+        disposeSandbox: false,
+        createTask: (text, taskOptions) => this.runTask(threadId, text, taskOptions),
+        onClose: (closedSession) => {
+          this.sessions.delete(closedSession);
+        },
+      },
+    );
+    this.sessions.add(session);
+    return session;
+  }
+
+  async runWorkflow<TOutput extends JsonValue = JsonValue, TInput extends JsonValue = JsonValue>(
+    runOptions: PiCamlFlowWorkflowRunOptions<TInput>,
+  ): Promise<PiCamlFlowWorkflowRunResult<TOutput>> {
+    const sandbox = await this.getSandbox();
+    this.assertOpen();
+    const host = createPiCamlFlowHostSession({
+      runtime: {
+        ...this.runtime,
+        cwd: sandbox.cwd,
+        sandbox: {
+          kind: "custom",
+          cwd: sandbox.cwd,
+          tools: sandbox.tools,
+          ...(sandbox.shell ? { shell: sandbox.shell } : {}),
+        },
+      },
+      camlflow: this.options.camlflow,
+      clientFactory: this.options.clientFactory,
+      workerSessionFactory: this.options.workerSessionFactory,
+      autoShutdown: this.options.autoShutdown,
+      onTrace: this.options.onTrace,
+      onDiagnostic: this.options.onDiagnostic,
+      onProgress: this.options.onProgress,
+      onOutputChunk: this.options.onOutputChunk,
+      onTransportError: this.options.onTransportError,
+    });
+    if (this.closed) {
+      await host.close();
+      throw new Error(`Pi CamlFlow agent is closed: ${this.id}`);
+    }
+    this.activeHosts.add(host);
+    try {
+      return await host.runWorkflow<TOutput, TInput>(runOptions);
+    } finally {
+      this.activeHosts.delete(host);
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+
+    let closeError: unknown;
+    const rememberError = (error: unknown): void => {
+      closeError ??= error;
+    };
+
+    const sessionResults = await Promise.allSettled(
+      Array.from(this.sessions, (session) => session.close()),
+    );
+    for (const result of sessionResults) {
+      if (result.status === "rejected") {
+        rememberError(result.reason);
+      }
+    }
+    this.sessions.clear();
+
+    const hostResults = await Promise.allSettled(
+      Array.from(this.activeHosts, (host) => host.close()),
+    );
+    for (const result of hostResults) {
+      if (result.status === "rejected") {
+        rememberError(result.reason);
+      }
+    }
+    this.activeHosts.clear();
+
+    if (this.sandboxPromise) {
+      const sandboxResult = await Promise.allSettled([this.sandboxPromise]);
+      if (sandboxResult[0].status === "fulfilled") {
+        try {
+          await sandboxResult[0].value.dispose();
+        } catch (error) {
+          rememberError(error);
+        }
+      }
+    }
+
+    if (closeError) {
+      throw closeError;
+    }
+  }
+
+  private getSandbox(): Promise<ResolvedPiCamlFlowSandbox> {
+    this.assertOpen();
+    this.sandboxPromise ??= resolvePiCamlFlowSandbox(
+      this.runtime.sandbox === undefined ? "local" : this.runtime.sandbox,
+      this.runtime.cwd,
+    );
+    return this.sandboxPromise;
+  }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      throw new Error(`Pi CamlFlow agent is closed: ${this.id}`);
+    }
+  }
+
+  private async runTask<TOutput>(
+    parentThreadId: string,
+    text: string,
+    options: PiCamlFlowPromptOptions<TOutput> | undefined,
+  ): Promise<TOutput> {
+    const taskId = `${parentThreadId}:task-${++this.taskIndex}`;
+    const taskSession = await this.session(taskId);
+    let primaryError: unknown;
+    try {
+      return await taskSession.prompt(text, options);
+    } catch (error) {
+      primaryError = error;
+      throw error;
+    } finally {
+      try {
+        await taskSession.close();
+      } catch (error) {
+        if (primaryError === undefined) {
+          throw error;
+        }
+      }
+    }
+  }
+}
+
+class DefaultPiCamlFlowAgentSession implements PiCamlFlowAgentSession {
+  private closed = false;
+  private promptActive = false;
+  private readonly promptSettlements = new Set<Promise<void>>();
+  private readonly shellControllers = new Set<AbortController>();
+  private readonly shellSettlements = new Set<Promise<void>>();
+
+  constructor(
+    readonly id: string,
+    private readonly sandbox: ResolvedPiCamlFlowSandbox,
+    private readonly session: PiCamlFlowWorkerSession,
+    private readonly lifecycle: {
+      disposeSandbox?: boolean;
+      createTask?: <TOutput>(
+        text: string,
+        options: PiCamlFlowPromptOptions<TOutput> | undefined,
+      ) => Promise<TOutput>;
+      onClose?: (session: DefaultPiCamlFlowAgentSession) => void;
+    } = {},
+  ) {}
+
+  get cwd(): string {
+    return this.sandbox.cwd;
+  }
+
+  async prompt<TOutput = string>(
+    text: string,
+    options: PiCamlFlowPromptOptions<TOutput> = {},
+  ): Promise<TOutput> {
+    if (this.closed) {
+      throw new Error(`Pi CamlFlow session is closed: ${this.id}`);
+    }
+    validateHarnessPromptText(text);
+    validatePromptOptions(options, "Pi harness prompt options");
+    if (options.signal?.aborted) {
+      throw new PiCamlFlowEffectCancelledError({ kind: "harness-session", name: this.id });
+    }
+    if (this.promptActive) {
+      throw new Error(`Pi CamlFlow session already has an active prompt: ${this.id}`);
+    }
+
+    const abortHandler = (): void => {
+      void this.session.abort();
+    };
+    options.signal?.addEventListener("abort", abortHandler, { once: true });
+    this.promptActive = true;
+    let promptSettlement: Promise<void> | undefined;
+    let primaryError: unknown;
+
+    try {
+      const messageStart = this.session.messages.length;
+      const promptRun = this.session.prompt(text, {
+        expandPromptTemplates: true,
+        source: "extension",
+      });
+      const settlement = promptRun.then(
+        () => undefined,
+        () => undefined,
+      );
+      promptSettlement = settlement;
+      this.promptSettlements.add(settlement);
+      settlement.finally(() => {
+        this.promptSettlements.delete(settlement);
+      });
+      await promptRun;
+
+      const assistant = findLastAssistantMessage(this.session.messages.slice(messageStart));
+      if (!assistant) {
+        throw new Error(`Pi harness session produced no assistant message: ${this.id}`);
+      }
+      validateAssistantMessageStatus(assistant);
+      if (assistant.stopReason === "aborted") {
+        throw new PiCamlFlowEffectCancelledError({ kind: "harness-session", name: this.id });
+      }
+      if (assistant.stopReason === "error") {
+        throw new Error(
+          assistant.errorMessage
+            ? `Pi harness session failed: ${assistant.errorMessage}`
+            : `Pi harness session failed: ${this.id}`,
+        );
+      }
+
+      const outputText = extractAssistantText(assistant);
+      return parseHarnessResult(outputText, options.result);
+    } catch (error) {
+      primaryError = error;
+      throw error;
+    } finally {
+      let cleanupError: unknown;
+      this.promptActive = false;
+      if (promptSettlement) {
+        this.promptSettlements.delete(promptSettlement);
+      }
+      try {
+        options.signal?.removeEventListener("abort", abortHandler);
+      } catch (error) {
+        cleanupError = error;
+      }
+      if (primaryError === undefined && cleanupError !== undefined) {
+        throw cleanupError;
+      }
+    }
+  }
+
+  async skill<TOutput = string>(
+    name: string,
+    options: PiCamlFlowSkillOptions<TOutput> = {},
+  ): Promise<TOutput> {
+    validateSkillOptions(options);
+    const prompt = buildSkillPrompt(name, options.args);
+    return await this.prompt(prompt, options);
+  }
+
+  async task<TOutput = string>(
+    text: string,
+    options: PiCamlFlowPromptOptions<TOutput> = {},
+  ): Promise<TOutput> {
+    if (this.closed) {
+      throw new Error(`Pi CamlFlow session is closed: ${this.id}`);
+    }
+    validateHarnessPromptText(text);
+    validatePromptOptions(options, "Pi harness task options");
+    if (!this.lifecycle.createTask) {
+      throw new Error(`Pi CamlFlow session cannot create tasks: ${this.id}`);
+    }
+    return await this.lifecycle.createTask(text, options);
+  }
+
+  async shell(
+    command: string,
+    options: PiCamlFlowHarnessShellOptions = {},
+  ): Promise<PiCamlFlowShellResult> {
+    if (this.closed) {
+      throw new Error(`Pi CamlFlow session is closed: ${this.id}`);
+    }
+    validateShellCommand(command);
+    validateShellOptions(options);
+    if (!this.sandbox.shell) {
+      throw new Error(`Sandbox ${this.sandbox.kind} does not allow host shell execution`);
+    }
+    if (options.signal?.aborted) {
+      return cancelledShellResult();
+    }
+
+    const controller = new AbortController();
+    this.shellControllers.add(controller);
+    const abortSignal = combineAbortSignals([options.signal, controller.signal]);
+    let primaryError: unknown;
+    try {
+      const shellRun = Promise.resolve(
+        this.sandbox.shell(command, {
+          ...options,
+          cwd: resolveSandboxCwd(this.sandbox.cwd, options.cwd),
+          signal: abortSignal.signal,
+        }),
+      );
+      const settlement = shellRun.then(
+        () => undefined,
+        () => undefined,
+      );
+      this.shellSettlements.add(settlement);
+      settlement.finally(() => {
+        this.shellSettlements.delete(settlement);
+      });
+      return validateShellResult(await shellRun);
+    } catch (error) {
+      primaryError = error;
+      throw error;
+    } finally {
+      let cleanupError: unknown;
+      try {
+        abortSignal.cleanup();
+      } catch (error) {
+        cleanupError = error;
+      }
+      this.shellControllers.delete(controller);
+      if (primaryError === undefined && cleanupError !== undefined) {
+        throw cleanupError;
+      }
+    }
+  }
+
+  async abort(): Promise<void> {
+    for (const controller of this.shellControllers) {
+      controller.abort();
+    }
+    await this.session.abort();
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+
+    let closeError: unknown;
+    const rememberError = (error: unknown): void => {
+      closeError ??= error;
+    };
+
+    try {
+      await this.abort();
+    } catch (error) {
+      rememberError(error);
+    }
+
+    const promptResults = await Promise.allSettled(Array.from(this.promptSettlements));
+    for (const result of promptResults) {
+      if (result.status === "rejected") {
+        rememberError(result.reason);
+      }
+    }
+
+    const shellResults = await Promise.allSettled(Array.from(this.shellSettlements));
+    for (const result of shellResults) {
+      if (result.status === "rejected") {
+        rememberError(result.reason);
+      }
+    }
+
+    try {
+      this.session.dispose();
+    } catch (error) {
+      rememberError(error);
+    }
+
+    try {
+      if (this.lifecycle.disposeSandbox !== false) {
+        await this.sandbox.dispose();
+      }
+    } catch (error) {
+      rememberError(error);
+    }
+
+    try {
+      this.lifecycle.onClose?.(this);
+    } catch (error) {
+      rememberError(error);
+    }
+    if (closeError) {
+      throw closeError;
+    }
+  }
+}
+
 async function createDefaultWorkerSession(
   _request: PiCamlFlowEffectRequest,
   options: {
@@ -432,29 +1185,33 @@ async function createDefaultWorkerSession(
     runtime: PiCamlFlowRuntime;
   },
 ): Promise<PiCamlFlowWorkerSession> {
+  const sandbox = await resolvePiCamlFlowSandbox(options.runtime.sandbox, options.cwd);
   const resourceLoader = createWorkerResourceLoader();
   const settingsManager = SettingsManager.inMemory({
     compaction: { enabled: false },
     retry: { enabled: false },
   });
 
-  const result = await createAgentSession({
-    cwd: options.cwd,
-    agentDir: options.runtime.services.agentDir,
-    authStorage: options.runtime.services.authStorage,
-    modelRegistry: options.runtime.services.modelRegistry,
-    model: options.model,
-    thinkingLevel: options.thinkingLevel,
-    tools: createCodingTools(options.cwd),
-    resourceLoader,
-    sessionManager: SessionManager.inMemory(),
-    settingsManager,
-  });
+  let result: Awaited<ReturnType<typeof createAgentSession>>;
+  try {
+    result = await createAgentSession({
+      cwd: sandbox.cwd,
+      agentDir: options.runtime.services.agentDir,
+      authStorage: options.runtime.services.authStorage,
+      modelRegistry: options.runtime.services.modelRegistry,
+      model: options.model,
+      thinkingLevel: options.thinkingLevel,
+      tools: sandbox.tools,
+      resourceLoader,
+      sessionManager: SessionManager.inMemory(),
+      settingsManager,
+    });
+  } catch (error) {
+    await sandbox.dispose().catch(() => undefined);
+    throw error;
+  }
 
-  return result.session as Pick<
-    AgentSession,
-    "messages" | "prompt" | "subscribe" | "abort" | "dispose"
-  >;
+  return wrapAgentSession(result.session, sandbox);
 }
 
 function createWorkerResourceLoader(): ResourceLoader {
@@ -472,6 +1229,1638 @@ function createWorkerResourceLoader(): ResourceLoader {
   };
 }
 
+function validateWorkflowRunOptions(options: PiCamlFlowWorkflowRunOptions): void {
+  if (typeof options !== "object" || options === null || Array.isArray(options)) {
+    throw new Error("CamlFlow workflow options must be an object");
+  }
+  validateNonEmptyString(options.workflowPath, "CamlFlow workflowPath");
+  validateNoNulString(options.workflowPath, "CamlFlow workflowPath");
+  if (options.entrypoint !== undefined) {
+    validateNonEmptyString(options.entrypoint, "CamlFlow entrypoint");
+    validateNoNulString(options.entrypoint, "CamlFlow entrypoint");
+  }
+  if (options.skillsDir !== undefined && options.skillsDir !== null) {
+    validateNonEmptyString(options.skillsDir, "CamlFlow skillsDir");
+    validateNoNulString(options.skillsDir, "CamlFlow skillsDir");
+  }
+  if (options.includePaths !== undefined && !Array.isArray(options.includePaths)) {
+    throw new Error("CamlFlow includePaths must be an array of non-empty strings");
+  }
+  for (const includePath of options.includePaths ?? []) {
+    if (typeof includePath !== "string" || includePath.trim().length === 0) {
+      throw new Error("CamlFlow includePaths must not contain empty paths");
+    }
+    validateNoNulString(includePath, "CamlFlow includePaths entry");
+  }
+  if (options.signal !== undefined) {
+    validateAbortSignal(options.signal, "CamlFlow workflow signal");
+  }
+  if (options.input !== undefined) {
+    stringifyPromptJson(options.input, "CamlFlow workflow input");
+  }
+}
+
+interface ResolvedPiCamlFlowSandbox {
+  kind: string;
+  cwd: string;
+  tools: PiTool[];
+  shell?: PiCamlFlowShellExecutor;
+  dispose(): Promise<void>;
+}
+
+type NormalizedPiCamlFlowSandboxConfig = Omit<PiCamlFlowSandboxConfig, "kind"> & {
+  kind?: PiCamlFlowSandboxPreset | "custom";
+  dispose?: () => MaybePromise<void>;
+};
+
+async function resolvePiCamlFlowSandbox(
+  input: PiCamlFlowSandboxInput | undefined,
+  fallbackCwd: string,
+): Promise<ResolvedPiCamlFlowSandbox> {
+  const config = await normalizeSandboxInput(input, fallbackCwd);
+  validateNormalizedSandboxConfig(config);
+  const kind = config.kind ?? "local";
+  validateSandboxConfig(config, kind);
+  validateSandboxKind(kind);
+  if (kind === "custom" && config.tools === undefined) {
+    throw new Error("Custom Pi CamlFlow sandboxes must provide tools");
+  }
+  const cwd =
+    kind === "ephemeral"
+      ? await mkdtemp(resolve(tmpdir(), "camlflow-pi-"))
+      : config.cwd ?? fallbackCwd;
+  const cleanup = kind === "ephemeral" && config.cleanup !== false;
+  let disposed = false;
+  const dispose = async (): Promise<void> => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    let disposeError: unknown;
+    try {
+      await config.dispose?.();
+    } catch (error) {
+      disposeError = error;
+    }
+    try {
+      if (cleanup) {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    } catch (error) {
+      disposeError ??= error;
+    }
+    if (disposeError) {
+      throw disposeError;
+    }
+  };
+
+  let tools: PiTool[];
+  try {
+    tools = config.tools
+      ? typeof config.tools === "function"
+        ? config.tools(cwd)
+        : config.tools
+      : kind === "read-only"
+        ? createReadOnlyTools(cwd)
+        : createCodingTools(cwd);
+    validateSandboxTools(tools);
+  } catch (error) {
+    await dispose().catch(() => undefined);
+    throw error;
+  }
+
+  const shell =
+    config.shell === false
+      ? undefined
+      : config.shell ??
+        (kind === "read-only" || kind === "custom"
+          ? undefined
+          : createLocalShellExecutor(cwd));
+
+  return {
+    kind,
+    cwd,
+    tools,
+    shell,
+    dispose,
+  };
+}
+
+function validateSandboxKind(kind: string): void {
+  if (typeof kind !== "string" || kind.trim().length === 0) {
+    throw new Error("Pi CamlFlow sandbox kind must not be empty");
+  }
+  if (kind !== "custom" && !SANDBOX_PRESETS.has(kind)) {
+    throw new Error(`Unknown Pi CamlFlow sandbox kind: ${kind}`);
+  }
+}
+
+function validateSandboxConfig(
+  config: NormalizedPiCamlFlowSandboxConfig,
+  kind: string,
+): void {
+  if (config.cwd !== undefined) {
+    validateNonEmptyString(config.cwd, "Pi CamlFlow sandbox cwd");
+    validateNoNulString(config.cwd, "Pi CamlFlow sandbox cwd");
+  }
+  if (
+    config.tools !== undefined &&
+    !Array.isArray(config.tools) &&
+    typeof config.tools !== "function"
+  ) {
+    throw new Error("Pi CamlFlow sandbox tools must be an array or factory");
+  }
+  if (
+    config.shell !== undefined &&
+    config.shell !== false &&
+    typeof config.shell !== "function"
+  ) {
+    throw new Error("Pi CamlFlow sandbox shell must be a function or false");
+  }
+  if (config.cleanup !== undefined && typeof config.cleanup !== "boolean") {
+    throw new Error("Pi CamlFlow sandbox cleanup must be a boolean");
+  }
+  if (config.dispose !== undefined && typeof config.dispose !== "function") {
+    throw new Error("Pi CamlFlow sandbox dispose must be a function");
+  }
+  if (kind !== "ephemeral" && config.cleanup !== undefined) {
+    throw new Error("Pi CamlFlow sandbox cleanup is only supported for ephemeral sandboxes");
+  }
+}
+
+function validateSandboxTools(tools: unknown): asserts tools is PiTool[] {
+  if (!Array.isArray(tools)) {
+    throw new Error("Pi CamlFlow sandbox tools must be an array or factory");
+  }
+}
+
+function normalizeSandboxInput(
+  input: PiCamlFlowSandboxInput | undefined,
+  fallbackCwd: string,
+  options: { allowDefault?: boolean } = { allowDefault: true },
+): Promise<NormalizedPiCamlFlowSandboxConfig> | NormalizedPiCamlFlowSandboxConfig {
+  if (input === undefined) {
+    if (options.allowDefault === false) {
+      throw new Error("Pi CamlFlow sandbox factory must return a sandbox config");
+    }
+    return { kind: "local" };
+  }
+  if (input === null) {
+    throw new Error("Pi CamlFlow sandbox config must be an object, string, or factory");
+  }
+  if (typeof input === "string") {
+    return { kind: input };
+  }
+  if (typeof input === "function") {
+    return Promise.resolve(input(fallbackCwd)).then((resolved) =>
+      normalizeSandboxInput(resolved, fallbackCwd, { allowDefault: false }),
+    );
+  }
+  validateNormalizedSandboxConfig(input);
+  return input;
+}
+
+function validateNormalizedSandboxConfig(
+  config: unknown,
+): asserts config is NormalizedPiCamlFlowSandboxConfig {
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    throw new Error("Pi CamlFlow sandbox config must be an object, string, or factory");
+  }
+}
+
+async function createHarnessWorkerSession(
+  runtime: PiCamlFlowRuntime,
+  options: {
+    cwd: string;
+    model: PiModel;
+    thinkingLevel?: PiThinkingLevel;
+    sandbox: ResolvedPiCamlFlowSandbox;
+  },
+): Promise<PiCamlFlowWorkerSession> {
+  const resourceLoader = new DefaultResourceLoader({
+    cwd: options.cwd,
+    agentDir: runtime.services.agentDir,
+    settingsManager: SettingsManager.inMemory({
+      compaction: { enabled: false },
+      retry: { enabled: false },
+    }),
+  });
+  await resourceLoader.reload();
+
+  const result = await createAgentSession({
+    cwd: options.cwd,
+    agentDir: runtime.services.agentDir,
+    authStorage: runtime.services.authStorage,
+    modelRegistry: runtime.services.modelRegistry,
+    model: options.model,
+    thinkingLevel: options.thinkingLevel,
+    tools: options.sandbox.tools,
+    resourceLoader,
+    sessionManager: SessionManager.inMemory(),
+    settingsManager: SettingsManager.inMemory({
+      compaction: { enabled: false },
+      retry: { enabled: false },
+    }),
+  });
+
+  return wrapAgentSession(result.session, options.sandbox, { disposeSandbox: false });
+}
+
+function wrapAgentSession(
+  session: AgentSession,
+  sandbox: ResolvedPiCamlFlowSandbox,
+  options: { disposeSandbox?: boolean } = {},
+): PiCamlFlowWorkerSession {
+  return {
+    get messages() {
+      return session.messages;
+    },
+    prompt: session.prompt.bind(session),
+    subscribe: session.subscribe.bind(session),
+    abort: session.abort.bind(session),
+    dispose: () => {
+      session.dispose();
+      if (options.disposeSandbox !== false) {
+        void sandbox.dispose();
+      }
+    },
+  };
+}
+
+function createLocalShellExecutor(defaultCwd: string): PiCamlFlowShellExecutor {
+  return async (command, options = {}) =>
+    executeLocalShell(command, {
+      ...options,
+      cwd: resolveLocalShellCwd(defaultCwd, options.cwd),
+    });
+}
+
+function resolveSandboxCwd(baseCwd: string, requestedCwd: string | undefined): string {
+  const sandboxRoot = resolve(baseCwd);
+  const cwd = requestedCwd ? resolve(sandboxRoot, requestedCwd) : sandboxRoot;
+  const relativePath = relative(sandboxRoot, cwd);
+  if (relativePath !== "" && (relativePath.startsWith("..") || isAbsolute(relativePath))) {
+    throw new Error(`Shell cwd escapes sandbox root: ${requestedCwd}`);
+  }
+  return cwd;
+}
+
+function resolveLocalShellCwd(baseCwd: string, requestedCwd: string | undefined): string {
+  const cwd = resolveSandboxCwd(baseCwd, requestedCwd);
+  const realSandboxRoot = realpathSync(baseCwd);
+  const realCwd = realpathSync(cwd);
+  const relativePath = relative(realSandboxRoot, realCwd);
+  if (relativePath !== "" && (relativePath.startsWith("..") || isAbsolute(relativePath))) {
+    throw new Error(`Shell cwd escapes sandbox root: ${requestedCwd}`);
+  }
+  return realCwd;
+}
+
+function executeLocalShell(
+  command: string,
+  options: PiCamlFlowShellOptions = {},
+): Promise<PiCamlFlowShellResult> {
+  if (options.signal?.aborted) {
+    return Promise.resolve(cancelledShellResult());
+  }
+
+  return new Promise((resolveShell, reject) => {
+    const detached = process.platform !== "win32";
+    const child = spawn(command, {
+      cwd: options.cwd,
+      env: { ...process.env, ...options.env },
+      detached,
+      shell: true,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let settled = false;
+    let timeout: NodeJS.Timeout | undefined;
+    const cleanup = (): void => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      options.signal?.removeEventListener("abort", abortHandler);
+    };
+    const terminate = (): void => {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        return;
+      }
+      if (detached && child.pid !== undefined) {
+        try {
+          process.kill(-child.pid, "SIGTERM");
+          return;
+        } catch {
+          child.kill("SIGTERM");
+          return;
+        }
+      }
+      child.kill("SIGTERM");
+    };
+    const abortHandler = (): void => {
+      terminate();
+    };
+    options.signal?.addEventListener("abort", abortHandler, { once: true });
+    if (options.signal?.aborted) {
+      terminate();
+    }
+    timeout =
+      options.timeoutMs === undefined
+        ? undefined
+        : setTimeout(() => {
+            terminate();
+          }, options.timeoutMs);
+
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.on("error", (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(error);
+    });
+    child.on("close", (code, signal) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolveShell({
+        code,
+        signal,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+      });
+    });
+
+    if (options.stdin !== undefined) {
+      child.stdin.end(options.stdin);
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+function cancelledShellResult(): PiCamlFlowShellResult {
+  return {
+    code: null,
+    signal: "SIGTERM",
+    stdout: "",
+    stderr: "",
+  };
+}
+
+function parseHarnessResult<TOutput>(
+  outputText: string,
+  parser: PiCamlFlowResultParser<TOutput> | undefined,
+): TOutput {
+  if (parser === undefined) {
+    return outputText as TOutput;
+  }
+
+  const json = parseCamlFlowJsonOutput(outputText);
+  if (parser === "json") {
+    return json as TOutput;
+  }
+  if (typeof parser === "function") {
+    return parser(json);
+  }
+
+  if (typeof parser !== "object" || parser === null) {
+    throw new Error("Pi harness result parser must be \"json\", a function, parse(value), or safeParse(value)");
+  }
+  if ("parse" in parser) {
+    if (typeof parser.parse !== "function") {
+      throw new Error("Pi harness result parser parse must be a function");
+    }
+    return parser.parse(json);
+  }
+  if (!("safeParse" in parser) || typeof parser.safeParse !== "function") {
+    throw new Error("Pi harness result parser must be \"json\", a function, parse(value), or safeParse(value)");
+  }
+  const result = parser.safeParse(json);
+  if (typeof result !== "object" || result === null || !("success" in result)) {
+    throw new Error("Pi harness result safeParse must return a success result");
+  }
+  if (result.success === true) {
+    if (!("output" in result) && !("data" in result)) {
+      throw new Error("Pi harness result safeParse success must include output or data");
+    }
+    return "output" in result
+      ? (result as { output: TOutput }).output
+      : (result as { data: TOutput }).data;
+  }
+  if (result.success !== false) {
+    throw new Error("Pi harness result safeParse must return a success result");
+  }
+  throw new Error(
+    `Pi harness result failed schema validation: ${formatSchemaIssues(result)}`,
+  );
+}
+
+function validateResultParserOption(parser: unknown): void {
+  if (parser === undefined) {
+    return;
+  }
+  if (parser === "json" || typeof parser === "function") {
+    return;
+  }
+  if (typeof parser !== "object" || parser === null || Array.isArray(parser)) {
+    throw new Error("Pi harness result parser must be \"json\", a function, parse(value), or safeParse(value)");
+  }
+  if ("parse" in parser) {
+    if (typeof (parser as { parse?: unknown }).parse !== "function") {
+      throw new Error("Pi harness result parser parse must be a function");
+    }
+    return;
+  }
+  if (typeof (parser as { safeParse?: unknown }).safeParse !== "function") {
+    throw new Error("Pi harness result parser must be \"json\", a function, parse(value), or safeParse(value)");
+  }
+}
+
+function formatSchemaIssues(result: { issues?: unknown; error?: unknown }): string {
+  const details = result.issues ?? result.error ?? [];
+  if (details instanceof Error) {
+    return details.message;
+  }
+  return JSON.stringify(details);
+}
+
+function buildSkillPrompt(name: string, args: JsonValue | undefined): string {
+  validateSkillName(name);
+  if (args !== undefined) {
+    return `/skill:${name} ${stringifyPromptJson(args, "Pi skill args")}`;
+  }
+  return `/skill:${name}`;
+}
+
+function validateSkillName(name: string): void {
+  if (
+    typeof name !== "string" ||
+    name.length === 0 ||
+    name.length > 64 ||
+    !/^[a-z0-9-]+$/.test(name) ||
+    name.startsWith("-") ||
+    name.endsWith("-") ||
+    name.includes("--")
+  ) {
+    throw new Error(
+      `Invalid Pi skill name "${name}": use lowercase letters, digits, and single hyphens only`,
+    );
+  }
+}
+
+function validateHarnessPromptText(text: string): void {
+  if (typeof text !== "string" || text.trim().length === 0) {
+    throw new Error("Pi harness prompt text must not be empty");
+  }
+}
+
+function validateShellCommand(command: string): void {
+  if (typeof command !== "string" || command.trim().length === 0) {
+    throw new Error("Pi harness shell command must not be empty");
+  }
+  validateNoNulString(command, "Pi harness shell command");
+}
+
+function validateShellOptions(options: PiCamlFlowShellOptions): void {
+  if (typeof options !== "object" || options === null || Array.isArray(options)) {
+    throw new Error("Pi harness shell options must be an object");
+  }
+  if (options.cwd !== undefined) {
+    validateNonEmptyString(options.cwd, "Pi harness shell cwd");
+    validateNoNulString(options.cwd, "Pi harness shell cwd");
+  }
+  if (options.env !== undefined) {
+    validateShellEnv(options.env, "Pi harness shell env");
+  }
+  if (options.stdin !== undefined && typeof options.stdin !== "string") {
+    throw new Error("Pi harness shell stdin must be a string");
+  }
+  if (options.stdin !== undefined) {
+    validateNoNulString(options.stdin, "Pi harness shell stdin");
+  }
+  if (
+    options.timeoutMs !== undefined &&
+    (!Number.isFinite(options.timeoutMs) || options.timeoutMs < 0)
+  ) {
+    throw new Error("Pi harness shell timeoutMs must be a finite non-negative number");
+  }
+  if (options.signal !== undefined) {
+    validateAbortSignal(options.signal, "Pi harness shell signal");
+  }
+}
+
+function validateShellResult(result: unknown): PiCamlFlowShellResult {
+  if (typeof result !== "object" || result === null || Array.isArray(result)) {
+    throw new Error("Pi harness shell executor returned an invalid shell result");
+  }
+  const candidate = result as PiCamlFlowShellResult;
+  if (
+    candidate.code !== null &&
+    (typeof candidate.code !== "number" ||
+      !Number.isInteger(candidate.code) ||
+      candidate.code < 0)
+  ) {
+    throw new Error("Pi harness shell executor returned an invalid shell result");
+  }
+  if (candidate.signal !== null) {
+    validateNonEmptyString(candidate.signal, "Pi harness shell result signal");
+    validateNoNulString(candidate.signal, "Pi harness shell result signal");
+  }
+  if (typeof candidate.stdout !== "string" || typeof candidate.stderr !== "string") {
+    throw new Error("Pi harness shell executor returned an invalid shell result");
+  }
+  return candidate;
+}
+
+function validateWorkerSession(
+  session: unknown,
+  label: string,
+): asserts session is PiCamlFlowWorkerSession {
+  if (typeof session !== "object" || session === null) {
+    throw new Error(`${label} must be an object`);
+  }
+  const candidate = session as PiCamlFlowWorkerSession;
+  if (!Array.isArray(candidate.messages)) {
+    throw new Error(`${label} must provide a messages array`);
+  }
+  if (
+    typeof candidate.prompt !== "function" ||
+    typeof candidate.subscribe !== "function" ||
+    typeof candidate.abort !== "function" ||
+    typeof candidate.dispose !== "function"
+  ) {
+    throw new Error(`${label} must provide prompt, subscribe, abort, and dispose`);
+  }
+}
+
+function validatePromptOptions(
+  options: PiCamlFlowPromptOptions<unknown>,
+  label: string,
+): void {
+  if (typeof options !== "object" || options === null || Array.isArray(options)) {
+    throw new Error(`${label} must be an object`);
+  }
+  if (options.signal !== undefined) {
+    validateAbortSignal(options.signal, `${label} signal`);
+  }
+  validateResultParserOption(options.result);
+}
+
+function validateSkillOptions(options: PiCamlFlowSkillOptions<unknown>): void {
+  validatePromptOptions(options, "Pi harness skill options");
+}
+
+function validateAbortSignal(signal: unknown, label: string): asserts signal is AbortSignal {
+  if (
+    typeof signal !== "object" ||
+    signal === null ||
+    typeof (signal as AbortSignal).aborted !== "boolean" ||
+    typeof (signal as AbortSignal).addEventListener !== "function" ||
+    typeof (signal as AbortSignal).removeEventListener !== "function"
+  ) {
+    throw new Error(`${label} must be an AbortSignal`);
+  }
+}
+
+function validateCamlFlowClient(client: unknown): asserts client is CamlFlowClientLike {
+  if (typeof client !== "object" || client === null) {
+    throw new Error("Pi CamlFlow JSON-RPC client must be an object");
+  }
+  const candidate = client as CamlFlowClientLike;
+  if (
+    typeof candidate.initialize !== "function" ||
+    typeof candidate.run !== "function" ||
+    typeof candidate.shutdownAndExit !== "function"
+  ) {
+    throw new Error("Pi CamlFlow JSON-RPC client must provide initialize, run, and shutdownAndExit");
+  }
+}
+
+function validateCamlFlowInitializeResult(
+  result: unknown,
+): asserts result is { protocolVersion: string; irVersion: string } {
+  if (typeof result !== "object" || result === null || Array.isArray(result)) {
+    throw new Error("Pi CamlFlow JSON-RPC initialize result must be an object");
+  }
+  stringifyPromptJson(result, "Pi CamlFlow JSON-RPC initialize result");
+  const candidate = result as {
+    protocolVersion?: unknown;
+    irVersion?: unknown;
+    capabilities?: unknown;
+    effectKinds?: unknown;
+  };
+  validateNonEmptyString(
+    candidate.protocolVersion,
+    "Pi CamlFlow JSON-RPC initialize result protocolVersion",
+  );
+  validateNoNulString(
+    candidate.protocolVersion,
+    "Pi CamlFlow JSON-RPC initialize result protocolVersion",
+  );
+  validateNonEmptyString(
+    candidate.irVersion,
+    "Pi CamlFlow JSON-RPC initialize result irVersion",
+  );
+  validateNoNulString(
+    candidate.irVersion,
+    "Pi CamlFlow JSON-RPC initialize result irVersion",
+  );
+  if (
+    typeof candidate.capabilities !== "object" ||
+    candidate.capabilities === null ||
+    Array.isArray(candidate.capabilities)
+  ) {
+    throw new Error(
+      "Pi CamlFlow JSON-RPC initialize result capabilities must be an object",
+    );
+  }
+  for (const name of CAMLFLOW_CAPABILITY_NAMES) {
+    const capability = (candidate.capabilities as Record<string, unknown>)[name];
+    if (capability !== true && capability !== false) {
+      throw new Error(
+        `Pi CamlFlow JSON-RPC initialize result capabilities.${name} must be a boolean`,
+      );
+    }
+  }
+  if (!Array.isArray(candidate.effectKinds)) {
+    throw new Error("Pi CamlFlow JSON-RPC initialize result effectKinds must be an array");
+  }
+  for (const [index, kind] of candidate.effectKinds.entries()) {
+    if (
+      kind !== "bound-agent" &&
+      kind !== "bound-skill" &&
+      kind !== "local-prompt-skill" &&
+      kind !== "inline-agent"
+    ) {
+      throw new Error(
+        `Pi CamlFlow JSON-RPC initialize result effectKinds[${index}] is invalid`,
+      );
+    }
+  }
+}
+
+function validateCamlFlowRunResult<TOutput extends JsonValue>(
+  result: unknown,
+): asserts result is CamlFlowRunResult<TOutput> {
+  if (typeof result !== "object" || result === null || Array.isArray(result)) {
+    throw new Error("Pi CamlFlow JSON-RPC run result must be an object");
+  }
+  stringifyPromptJson(result, "Pi CamlFlow JSON-RPC run result");
+  const candidate = result as {
+    runId?: unknown;
+    stepsRun?: unknown;
+    output?: unknown;
+  };
+  validateNonEmptyString(candidate.runId, "Pi CamlFlow JSON-RPC run result runId");
+  validateNoNulString(candidate.runId, "Pi CamlFlow JSON-RPC run result runId");
+  if (
+    typeof candidate.stepsRun !== "number" ||
+    !Number.isInteger(candidate.stepsRun) ||
+    candidate.stepsRun < 0
+  ) {
+    throw new Error(
+      "Pi CamlFlow JSON-RPC run result stepsRun must be a non-negative integer",
+    );
+  }
+  stringifyPromptJson(candidate.output, "Pi CamlFlow JSON-RPC run result output");
+}
+
+function wrapTraceCallback(
+  callback: PiCamlFlowCallbacks["onTrace"],
+): PiCamlFlowCallbacks["onTrace"] {
+  if (!callback) {
+    return undefined;
+  }
+  return async (trace, notification) => {
+    validateCamlFlowTraceNotification(trace);
+    const params = validateJsonRpcNotification(
+      notification,
+      CamlFlowRpc.CAMLFLOW_METHODS.trace,
+      "Pi CamlFlow JSON-RPC trace notification",
+    );
+    validateCamlFlowTraceNotification(params);
+    await callback(params as CamlFlowTraceNotification, notification);
+  };
+}
+
+function wrapDiagnosticCallback(
+  callback: PiCamlFlowCallbacks["onDiagnostic"],
+): PiCamlFlowCallbacks["onDiagnostic"] {
+  if (!callback) {
+    return undefined;
+  }
+  return async (diagnostic, notification) => {
+    validateCamlFlowDiagnosticNotification(diagnostic);
+    const params = validateJsonRpcNotification(
+      notification,
+      CamlFlowRpc.CAMLFLOW_METHODS.diagnostic,
+      "Pi CamlFlow JSON-RPC diagnostic notification",
+    );
+    validateCamlFlowDiagnosticNotification(params);
+    await callback(params as CamlFlowDiagnosticNotification, notification);
+  };
+}
+
+function wrapProgressCallback(
+  callback: PiCamlFlowCallbacks["onProgress"],
+): PiCamlFlowCallbacks["onProgress"] {
+  if (!callback) {
+    return undefined;
+  }
+  return async (progress, notification) => {
+    validateCamlFlowProgressNotification(progress);
+    const params = validateJsonRpcNotification(
+      notification,
+      CamlFlowRpc.CAMLFLOW_METHODS.progress,
+      "Pi CamlFlow JSON-RPC progress notification",
+    );
+    validateCamlFlowProgressNotification(params);
+    await callback(params as CamlFlowProgressNotification, notification);
+  };
+}
+
+function wrapOutputChunkCallback(
+  callback: PiCamlFlowCallbacks["onOutputChunk"],
+): PiCamlFlowCallbacks["onOutputChunk"] {
+  if (!callback) {
+    return undefined;
+  }
+  return async (chunk, notification) => {
+    validateCamlFlowOutputChunkNotification(chunk);
+    const params = validateJsonRpcNotification(
+      notification,
+      CamlFlowRpc.CAMLFLOW_METHODS.outputChunk,
+      "Pi CamlFlow JSON-RPC outputChunk notification",
+    );
+    validateCamlFlowOutputChunkNotification(params);
+    await callback(params as CamlFlowOutputChunkNotification, notification);
+  };
+}
+
+function validateJsonRpcNotification(
+  notification: unknown,
+  expectedMethod: string,
+  label: string,
+): unknown {
+  if (typeof notification !== "object" || notification === null || Array.isArray(notification)) {
+    throw new Error(`${label} must be an object`);
+  }
+  stringifyPromptJson(notification, label);
+  const candidate = notification as {
+    jsonrpc?: unknown;
+    method?: unknown;
+    params?: unknown;
+  };
+  if (candidate.jsonrpc !== "2.0") {
+    throw new Error(`${label} jsonrpc must be 2.0`);
+  }
+  if (candidate.method !== expectedMethod) {
+    throw new Error(`${label} method must be ${expectedMethod}`);
+  }
+  if (candidate.params === undefined) {
+    throw new Error(`${label} params must be present`);
+  }
+  stringifyPromptJson(candidate.params, `${label} params`);
+  return candidate.params;
+}
+
+function validateCamlFlowTraceNotification(trace: unknown): void {
+  validateJsonObjectPayload(trace, "Pi CamlFlow JSON-RPC trace params");
+  const candidate = trace as CamlFlowTraceNotification;
+  if (
+    candidate.event !== "run-start" &&
+    candidate.event !== "effect-request" &&
+    candidate.event !== "effect-result" &&
+    candidate.event !== "effect-error" &&
+    candidate.event !== "run-finish" &&
+    candidate.event !== "run-error" &&
+    candidate.event !== "run-cancelled"
+  ) {
+    throw new Error("Pi CamlFlow JSON-RPC trace params event is invalid");
+  }
+  validateNullableRunId(candidate.runId, "Pi CamlFlow JSON-RPC trace params runId");
+  validateNullableStep(candidate.step, "Pi CamlFlow JSON-RPC trace params step");
+  validateNullableEffectSummary(
+    candidate.effect,
+    "Pi CamlFlow JSON-RPC trace params effect",
+  );
+  if (candidate.details !== undefined) {
+    stringifyPromptJson(candidate.details, "Pi CamlFlow JSON-RPC trace params details");
+  }
+}
+
+function validateCamlFlowDiagnosticNotification(diagnostic: unknown): void {
+  validateJsonObjectPayload(diagnostic, "Pi CamlFlow JSON-RPC diagnostic params");
+  const candidate = diagnostic as CamlFlowDiagnosticNotification;
+  if (candidate.severity !== "error") {
+    throw new Error("Pi CamlFlow JSON-RPC diagnostic params severity must be error");
+  }
+  validateNonEmptyString(candidate.message, "Pi CamlFlow JSON-RPC diagnostic params message");
+  validateNullableString(
+    candidate.method,
+    "Pi CamlFlow JSON-RPC diagnostic params method",
+    false,
+  );
+  validateNullableRunId(
+    candidate.runId,
+    "Pi CamlFlow JSON-RPC diagnostic params runId",
+  );
+  validateNullableStep(candidate.step, "Pi CamlFlow JSON-RPC diagnostic params step");
+  validateNullableEffectSummary(
+    candidate.effect,
+    "Pi CamlFlow JSON-RPC diagnostic params effect",
+  );
+}
+
+function validateCamlFlowProgressNotification(progress: unknown): void {
+  validateJsonObjectPayload(progress, "Pi CamlFlow JSON-RPC progress params");
+  const candidate = progress as CamlFlowProgressNotification;
+  validateNullableRunId(candidate.runId, "Pi CamlFlow JSON-RPC progress params runId");
+  validateNonEmptyString(candidate.stage, "Pi CamlFlow JSON-RPC progress params stage");
+  validateNullableStep(candidate.step, "Pi CamlFlow JSON-RPC progress params step");
+  validateNullableString(
+    candidate.message,
+    "Pi CamlFlow JSON-RPC progress params message",
+    false,
+  );
+  validateNullableStep(
+    candidate.completedSteps,
+    "Pi CamlFlow JSON-RPC progress params completedSteps",
+  );
+  validateNullableStep(
+    candidate.knownSteps,
+    "Pi CamlFlow JSON-RPC progress params knownSteps",
+  );
+  if (candidate.cancellable !== null && typeof candidate.cancellable !== "boolean") {
+    throw new Error("Pi CamlFlow JSON-RPC progress params cancellable must be boolean or null");
+  }
+}
+
+function validateCamlFlowOutputChunkNotification(chunk: unknown): void {
+  validateJsonObjectPayload(chunk, "Pi CamlFlow JSON-RPC outputChunk params");
+  const candidate = chunk as CamlFlowOutputChunkNotification;
+  validateNullableRunId(candidate.runId, "Pi CamlFlow JSON-RPC outputChunk params runId");
+  validateNullableStep(candidate.step, "Pi CamlFlow JSON-RPC outputChunk params step");
+  validateNonEmptyString(
+    candidate.streamId,
+    "Pi CamlFlow JSON-RPC outputChunk params streamId",
+  );
+  validateNoNulString(
+    candidate.streamId,
+    "Pi CamlFlow JSON-RPC outputChunk params streamId",
+  );
+  validateNonEmptyString(candidate.format, "Pi CamlFlow JSON-RPC outputChunk params format");
+  stringifyPromptJson(candidate.delta, "Pi CamlFlow JSON-RPC outputChunk params delta");
+  if (typeof candidate.done !== "boolean") {
+    throw new Error("Pi CamlFlow JSON-RPC outputChunk params done must be a boolean");
+  }
+  validateNullableString(
+    candidate.declaredReturnType,
+    "Pi CamlFlow JSON-RPC outputChunk params declaredReturnType",
+    true,
+  );
+  if (candidate.outputSchema !== null) {
+    validateJsonObjectPayload(
+      candidate.outputSchema,
+      "Pi CamlFlow JSON-RPC outputChunk params outputSchema",
+    );
+  }
+}
+
+function validateExecuteEffectParams(params: unknown): void {
+  validateJsonObjectPayload(params, "Pi CamlFlow JSON-RPC executeEffect params");
+  const candidate = params as {
+    runId?: unknown;
+    step?: unknown;
+    effect?: unknown;
+  };
+  validateNullableRunId(
+    candidate.runId,
+    "Pi CamlFlow JSON-RPC executeEffect params runId",
+  );
+  validateNullableStep(candidate.step, "Pi CamlFlow JSON-RPC executeEffect params step");
+  validateJsonObjectPayload(
+    candidate.effect,
+    "Pi CamlFlow JSON-RPC executeEffect params effect",
+  );
+  const effect = candidate.effect as {
+    kind?: unknown;
+    role?: unknown;
+    inlineDefinition?: unknown;
+    runId?: unknown;
+    step?: unknown;
+    unsupportedSettings?: unknown;
+  };
+  validateCamlFlowEffectKind(
+    effect.kind,
+    "Pi CamlFlow JSON-RPC executeEffect params effect kind",
+  );
+  if (effect.role !== "agent" && effect.role !== "skill") {
+    throw new Error("Pi CamlFlow JSON-RPC executeEffect params effect role is invalid");
+  }
+  validateEffectKindRolePair(effect.kind, effect.role);
+  validateExecuteEffectMetadataMatch(candidate.runId, effect.runId, "runId");
+  validateExecuteEffectMetadataMatch(candidate.step, effect.step, "step");
+  validateUnsupportedSettings(effect.unsupportedSettings);
+  validateNullableInlineDefinition(effect.inlineDefinition);
+  validateInlineDefinitionKindPair(effect.kind, effect.inlineDefinition);
+  validateEffectRequest(paramsToEffectRequest(params as CamlFlowExecuteEffectParams));
+}
+
+function validateExecuteEffectMetadataMatch(
+  paramsValue: unknown,
+  effectValue: unknown,
+  name: "runId" | "step",
+): void {
+  const label = `Pi CamlFlow JSON-RPC executeEffect params effect ${name}`;
+  if (name === "runId") {
+    validateNullableRunId(effectValue, label);
+  } else {
+    validateNullableStep(effectValue, label);
+  }
+  if (paramsValue !== effectValue) {
+    throw new Error(`Pi CamlFlow JSON-RPC executeEffect params ${name} metadata must match`);
+  }
+}
+
+function validateEffectKindRolePair(kind: unknown, role: unknown): void {
+  const expectedRole =
+    kind === "bound-agent" || kind === "inline-agent" ? "agent" : "skill";
+  if (role !== expectedRole) {
+    throw new Error(
+      "Pi CamlFlow JSON-RPC executeEffect params effect kind and role must match",
+    );
+  }
+}
+
+function validateUnsupportedSettings(value: unknown): void {
+  if (!Array.isArray(value)) {
+    throw new Error(
+      "Pi CamlFlow JSON-RPC executeEffect params effect unsupportedSettings must be an array",
+    );
+  }
+  for (const [index, setting] of value.entries()) {
+    validateNonEmptyString(
+      setting,
+      `Pi CamlFlow JSON-RPC executeEffect params effect unsupportedSettings[${index}]`,
+    );
+    validateNoNulString(
+      setting,
+      `Pi CamlFlow JSON-RPC executeEffect params effect unsupportedSettings[${index}]`,
+    );
+  }
+}
+
+function validateNullableInlineDefinition(value: unknown): void {
+  if (value === null) {
+    return;
+  }
+  const label = "Pi CamlFlow JSON-RPC executeEffect params effect inlineDefinition";
+  validateJsonObjectPayload(value, label);
+  const candidate = value as {
+    model?: unknown;
+    temperature?: unknown;
+    system_prompt?: unknown;
+    metadata?: unknown;
+    loc?: unknown;
+  };
+  validateNullableString(candidate.model, `${label} model`, false);
+  if (typeof candidate.model === "string") {
+    validateNoNulString(candidate.model, `${label} model`);
+  }
+  if (candidate.temperature !== null && typeof candidate.temperature !== "number") {
+    throw new Error(`${label} temperature must be a number or null`);
+  }
+  if (typeof candidate.temperature === "number" && !Number.isFinite(candidate.temperature)) {
+    throw new Error(`${label} temperature must be finite`);
+  }
+  validateNullableString(candidate.system_prompt, `${label} system_prompt`, true);
+  validateInlineMetadata(candidate.metadata, `${label} metadata`);
+  validateLocation(candidate.loc, `${label} loc`);
+}
+
+function validateInlineDefinitionKindPair(kind: unknown, inlineDefinition: unknown): void {
+  if (kind === "inline-agent" && inlineDefinition === null) {
+    throw new Error(
+      "Pi CamlFlow JSON-RPC executeEffect params effect inline-agent requires inlineDefinition",
+    );
+  }
+  if (kind !== "inline-agent" && inlineDefinition !== null) {
+    throw new Error(
+      "Pi CamlFlow JSON-RPC executeEffect params effect inlineDefinition requires inline-agent kind",
+    );
+  }
+}
+
+function validateInlineMetadata(value: unknown, label: string): void {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array`);
+  }
+  for (const [index, entry] of value.entries()) {
+    const entryLabel = `${label}[${index}]`;
+    validateJsonObjectPayload(entry, entryLabel);
+    const candidate = entry as { name?: unknown; value?: unknown };
+    validateNonEmptyString(candidate.name, `${entryLabel} name`);
+    validateNoNulString(candidate.name, `${entryLabel} name`);
+    validateInlineLiteral(candidate.value, `${entryLabel} value`);
+  }
+}
+
+function validateInlineLiteral(value: unknown, label: string): void {
+  validateJsonObjectPayload(value, label);
+  const candidate = value as { kind?: unknown; value?: unknown };
+  switch (candidate.kind) {
+    case "string":
+      if (typeof candidate.value !== "string") {
+        throw new Error(`${label} string value must be a string`);
+      }
+      return;
+    case "int":
+      if (!Number.isInteger(candidate.value)) {
+        throw new Error(`${label} int value must be an integer`);
+      }
+      return;
+    case "bool":
+      if (typeof candidate.value !== "boolean") {
+        throw new Error(`${label} bool value must be a boolean`);
+      }
+      return;
+    case "float":
+      if (typeof candidate.value !== "number" || !Number.isFinite(candidate.value)) {
+        throw new Error(`${label} float value must be finite`);
+      }
+      return;
+    case "unit":
+      if ("value" in candidate) {
+        throw new Error(`${label} unit value must be omitted`);
+      }
+      return;
+    default:
+      throw new Error(`${label} kind is invalid`);
+  }
+}
+
+function validateLocation(value: unknown, label: string): void {
+  validateJsonObjectPayload(value, label);
+  const candidate = value as { file?: unknown; start?: unknown; end?: unknown };
+  if (typeof candidate.file !== "string") {
+    throw new Error(`${label} file must be a string`);
+  }
+  validateNoNulString(candidate.file, `${label} file`);
+  validateLocationPosition(candidate.start, `${label} start`);
+  validateLocationPosition(candidate.end, `${label} end`);
+}
+
+function validateLocationPosition(value: unknown, label: string): void {
+  validateJsonObjectPayload(value, label);
+  const candidate = value as { line?: unknown; column?: unknown; offset?: unknown };
+  for (const name of ["line", "column", "offset"] as const) {
+    if (!Number.isInteger(candidate[name]) || (candidate[name] as number) < 0) {
+      throw new Error(`${label} ${name} must be a non-negative integer`);
+    }
+  }
+}
+
+function validateExecuteEffectRequest(request: unknown): CamlFlowExecuteEffectParams {
+  const params = validateJsonRpcRequest(
+    request,
+    CamlFlowRpc.CAMLFLOW_METHODS.executeEffect,
+    "Pi CamlFlow JSON-RPC executeEffect request",
+  );
+  validateExecuteEffectParams(params);
+  return params as CamlFlowExecuteEffectParams;
+}
+
+function validateEffectHandlerContext(context: unknown): void {
+  if (
+    typeof context !== "object" ||
+    context === null ||
+    Array.isArray(context) ||
+    typeof (context as Partial<CamlFlowEffectHandlerContext>).emitOutputChunk !== "function"
+  ) {
+    throw new Error(
+      "Pi CamlFlow JSON-RPC executeEffect context must provide emitOutputChunk",
+    );
+  }
+}
+
+function validateJsonRpcRequest(
+  request: unknown,
+  expectedMethod: string,
+  label: string,
+): unknown {
+  if (typeof request !== "object" || request === null || Array.isArray(request)) {
+    throw new Error(`${label} must be an object`);
+  }
+  stringifyPromptJson(request, label);
+  const candidate = request as {
+    jsonrpc?: unknown;
+    id?: unknown;
+    method?: unknown;
+    params?: unknown;
+  };
+  if (candidate.jsonrpc !== "2.0") {
+    throw new Error(`${label} jsonrpc must be 2.0`);
+  }
+  if (
+    (typeof candidate.id !== "string" && typeof candidate.id !== "number") ||
+    (typeof candidate.id === "number" &&
+      (!Number.isFinite(candidate.id) || !Number.isInteger(candidate.id)))
+  ) {
+    throw new Error(`${label} id must be a string or integer number`);
+  }
+  if (typeof candidate.id === "string") {
+    validateNoNulString(candidate.id, `${label} id`);
+  }
+  if (candidate.method !== expectedMethod) {
+    throw new Error(`${label} method must be ${expectedMethod}`);
+  }
+  if (candidate.params === undefined) {
+    throw new Error(`${label} params must be present`);
+  }
+  stringifyPromptJson(candidate.params, `${label} params`);
+  return candidate.params;
+}
+
+function validateJsonObjectPayload(value: unknown, label: string): void {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  stringifyPromptJson(value, label);
+}
+
+function validateNullableRunId(value: unknown, label: string): void {
+  validateNullableString(value, label, true);
+  if (typeof value === "string") {
+    validateNoNulString(value, label);
+  }
+}
+
+function validateNullableString(value: unknown, label: string, allowEmpty: boolean): void {
+  if (value === null) {
+    return;
+  }
+  if (allowEmpty) {
+    if (typeof value !== "string") {
+      throw new Error(`${label} must be a string or null`);
+    }
+    return;
+  }
+  validateNonEmptyString(value, label);
+}
+
+function validateNullableStep(value: unknown, label: string): void {
+  if (value !== null && (!Number.isInteger(value) || (value as number) < 0)) {
+    throw new Error(`${label} must be a non-negative integer or null`);
+  }
+}
+
+function validateNullableEffectSummary(value: unknown, label: string): void {
+  if (value === null) {
+    return;
+  }
+  validateJsonObjectPayload(value, label);
+  const candidate = value as { kind?: unknown; name?: unknown };
+  validateCamlFlowEffectKind(candidate.kind, `${label} kind`);
+  validateNonEmptyString(candidate.name, `${label} name`);
+}
+
+function validateCamlFlowEffectKind(value: unknown, label: string): void {
+  if (
+    value !== "bound-agent" &&
+    value !== "bound-skill" &&
+    value !== "local-prompt-skill" &&
+    value !== "inline-agent"
+  ) {
+    throw new Error(`${label} is invalid`);
+  }
+}
+
+function validateEffectExecutorOptions(options: PiCamlFlowEffectExecutorOptions): void {
+  if (typeof options !== "object" || options === null || Array.isArray(options)) {
+    throw new Error("Pi CamlFlow effect executor options must be an object");
+  }
+  validateWorkerSessionFactoryOption(options.workerSessionFactory);
+}
+
+function validateEffectExecutionOptions(options: PiCamlFlowEffectExecutionOptions): void {
+  if (typeof options !== "object" || options === null || Array.isArray(options)) {
+    throw new Error("Pi CamlFlow effect execution options must be an object");
+  }
+  if (options.signal !== undefined) {
+    validateAbortSignal(options.signal, "Pi CamlFlow effect execution signal");
+  }
+  if (
+    options.emitOutputChunk !== undefined &&
+    typeof options.emitOutputChunk !== "function"
+  ) {
+    throw new Error("Pi CamlFlow effect execution emitOutputChunk must be a function");
+  }
+}
+
+function validateHostSessionOptions(options: PiCamlFlowHostSessionOptions): void {
+  if (typeof options !== "object" || options === null || Array.isArray(options)) {
+    throw new Error("Pi CamlFlow host session options must be an object");
+  }
+  validateClientFactoryOption(options.clientFactory);
+  validateWorkerSessionFactoryOption(options.workerSessionFactory);
+  validateCallbackOptions(options);
+  validateCamlFlowSpawnOptions(options.camlflow, "Pi CamlFlow host session camlflow options");
+  if (options.autoShutdown !== undefined && typeof options.autoShutdown !== "boolean") {
+    throw new Error("Pi CamlFlow host session autoShutdown must be a boolean");
+  }
+}
+
+function validateHarnessOptions(options: PiCamlFlowHarnessOptions): void {
+  if (typeof options !== "object" || options === null || Array.isArray(options)) {
+    throw new Error("Pi CamlFlow harness options must be an object");
+  }
+  validateClientFactoryOption(options.clientFactory);
+  validateWorkerSessionFactoryOption(options.workerSessionFactory);
+  validateCallbackOptions(options);
+  validateCamlFlowSpawnOptions(options.camlflow, "Pi CamlFlow harness camlflow options");
+  if (options.autoShutdown !== undefined && typeof options.autoShutdown !== "boolean") {
+    throw new Error("Pi CamlFlow harness autoShutdown must be a boolean");
+  }
+}
+
+function validateClientFactoryOption(
+  factory: PiCamlFlowHostSessionOptions["clientFactory"] | undefined,
+): void {
+  if (factory !== undefined && typeof factory !== "function") {
+    throw new Error("Pi CamlFlow clientFactory must be a function");
+  }
+}
+
+function validateWorkerSessionFactoryOption(
+  factory: PiCamlFlowEffectExecutorOptions["workerSessionFactory"] | undefined,
+): void {
+  if (factory !== undefined && typeof factory !== "function") {
+    throw new Error("Pi CamlFlow workerSessionFactory must be a function");
+  }
+}
+
+function validateCallbackOptions(options: PiCamlFlowCallbacks): void {
+  for (const name of [
+    "onTrace",
+    "onDiagnostic",
+    "onProgress",
+    "onOutputChunk",
+    "onTransportError",
+  ] as const) {
+    if (options[name] !== undefined && typeof options[name] !== "function") {
+      throw new Error(`Pi CamlFlow ${name} callback must be a function`);
+    }
+  }
+}
+
+function validateCamlFlowSpawnOptions(
+  options: Partial<SpawnCamlFlowClientOptions> | undefined,
+  label: string,
+): void {
+  if (options === undefined) {
+    return;
+  }
+  if (typeof options !== "object" || options === null || Array.isArray(options)) {
+    throw new Error(`${label} must be an object`);
+  }
+  if (options.command !== undefined) {
+    validateNonEmptyString(options.command, `${label} command`);
+    validateNoNulString(options.command, `${label} command`);
+  }
+  if (options.args !== undefined) {
+    if (!Array.isArray(options.args)) {
+      throw new Error(`${label} args must be an array of strings`);
+    }
+    for (const arg of options.args) {
+      if (typeof arg !== "string") {
+        throw new Error(`${label} args must be an array of strings`);
+      }
+      validateNoNulString(arg, `${label} arg`);
+    }
+  }
+  if (options.cwd !== undefined) {
+    validateNonEmptyString(options.cwd, `${label} cwd`);
+    validateNoNulString(options.cwd, `${label} cwd`);
+  }
+  if (options.env !== undefined) {
+    validateShellEnv(options.env, `${label} env`);
+  }
+  if (
+    options.stderr !== undefined &&
+    options.stderr !== "inherit" &&
+    options.stderr !== "pipe"
+  ) {
+    throw new Error(`${label} stderr must be inherit or pipe`);
+  }
+  for (const name of [
+    "effectHandler",
+    "onTrace",
+    "onDiagnostic",
+    "onProgress",
+    "onOutputChunk",
+    "onNotification",
+    "onTransportError",
+  ] as const) {
+    if (options[name] !== undefined && typeof options[name] !== "function") {
+      throw new Error(`${label} ${name} must be a function`);
+    }
+  }
+}
+
+function validateShellEnv(env: unknown, label: string): void {
+  if (typeof env !== "object" || env === null || Array.isArray(env)) {
+    throw new Error(`${label} must be an object`);
+  }
+  validatePlainEnumerableRecord(env, label);
+  for (const [name, value] of Object.entries(env)) {
+    validateNonEmptyString(name, `${label} name`);
+    validateNoNulString(name, `${label} name`);
+    if (name.includes("=")) {
+      throw new Error(`${label} names must not contain =`);
+    }
+    if (typeof value !== "string" && value !== undefined) {
+      throw new Error(`${label} value for ${name} must be a string or undefined`);
+    }
+    if (typeof value === "string") {
+      validateNoNulString(value, `${label} value for ${name}`);
+    }
+  }
+}
+
+function validatePlainEnumerableRecord(value: object, label: string): void {
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error(`${label} must be a plain object`);
+  }
+  if (Object.getOwnPropertySymbols(value).length > 0) {
+    throw new Error(`${label} must not contain symbol keys`);
+  }
+  for (const key of Object.getOwnPropertyNames(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor && !descriptor.enumerable) {
+      throw new Error(`${label}.${key} must be enumerable`);
+    }
+  }
+}
+
+function validateNonEmptyString(value: unknown, label: string): asserts value is string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} must not be empty`);
+  }
+}
+
+function validateNoNulString(value: string, label: string): void {
+  if (value.includes("\0")) {
+    throw new Error(`${label} must not contain NUL bytes`);
+  }
+}
+
+function validateEffectRequest(request: PiCamlFlowEffectRequest): void {
+  if (typeof request !== "object" || request === null || Array.isArray(request)) {
+    throw new Error("CamlFlow effect request must be an object");
+  }
+  validateNonEmptyString(request.kind, "CamlFlow effect kind");
+  validateNoNulString(request.kind, "CamlFlow effect kind");
+  validateNonEmptyString(request.name, "CamlFlow effect name");
+  validateNoNulString(request.name, "CamlFlow effect name");
+  validateNonEmptyString(request.renderedPrompt, "CamlFlow effect renderedPrompt");
+  if (request.workingDirectory !== undefined && request.workingDirectory !== null) {
+    validateNonEmptyString(request.workingDirectory, "CamlFlow effect workingDirectory");
+    validateNoNulString(request.workingDirectory, "CamlFlow effect workingDirectory");
+  }
+  if (request.skillsDirectory !== undefined && request.skillsDirectory !== null) {
+    validateNonEmptyString(request.skillsDirectory, "CamlFlow effect skillsDirectory");
+    validateNoNulString(request.skillsDirectory, "CamlFlow effect skillsDirectory");
+  }
+  if (request.skillMarkdown !== undefined && request.skillMarkdown !== null) {
+    validateNonEmptyString(request.skillMarkdown, "CamlFlow effect skillMarkdown");
+  }
+  if (request.requestedModel !== undefined && request.requestedModel !== null) {
+    validateNonEmptyString(request.requestedModel, "CamlFlow effect requestedModel");
+    validateModelReference(request.requestedModel, "CamlFlow effect requestedModel");
+  }
+  if (request.declaredReturnType !== undefined) {
+    validateNonEmptyString(request.declaredReturnType, "CamlFlow effect declaredReturnType");
+    validateNoNulString(request.declaredReturnType, "CamlFlow effect declaredReturnType");
+  }
+  if (request.runId !== undefined && request.runId !== null) {
+    validateNonEmptyString(request.runId, "CamlFlow effect runId");
+    validateNoNulString(request.runId, "CamlFlow effect runId");
+  }
+  if (
+    request.step !== undefined &&
+    request.step !== null &&
+    (!Number.isInteger(request.step) || request.step < 0)
+  ) {
+    throw new Error("CamlFlow effect step must be a non-negative integer");
+  }
+  if (request.outputSchema !== undefined && request.outputSchema !== null) {
+    validateJsonObjectPayload(request.outputSchema, "CamlFlow effect outputSchema");
+  }
+  stringifyPromptJson(request.input, "CamlFlow effect input");
+}
+
+function stringifyPromptJson(value: unknown, label: string): string {
+  validateJsonValue(value, label);
+  try {
+    const encoded = JSON.stringify(value, null, 2);
+    if (encoded === undefined) {
+      throw new Error("value is not representable as JSON");
+    }
+    return encoded;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${label} must be JSON serializable: ${message}`);
+  }
+}
+
+function validateJsonValue(value: unknown, label: string): void {
+  const seen = new WeakSet<object>();
+  const visit = (candidate: unknown, path: string): void => {
+    if (
+      candidate === null ||
+      typeof candidate === "string" ||
+      typeof candidate === "boolean"
+    ) {
+      return;
+    }
+    if (typeof candidate === "number") {
+      if (!Number.isFinite(candidate)) {
+        throw new Error(`${path} must be a finite number`);
+      }
+      return;
+    }
+    if (
+      candidate === undefined ||
+      typeof candidate === "function" ||
+      typeof candidate === "symbol" ||
+      typeof candidate === "bigint"
+    ) {
+      throw new Error(`${path} has unsupported type ${typeof candidate}`);
+    }
+    if (typeof candidate !== "object") {
+      throw new Error(`${path} has unsupported type ${typeof candidate}`);
+    }
+    if (seen.has(candidate)) {
+      throw new Error(`${path} contains a circular reference`);
+    }
+    seen.add(candidate);
+    if (Array.isArray(candidate)) {
+      for (let index = 0; index < candidate.length; index += 1) {
+        if (!(index in candidate)) {
+          throw new Error(`${path}[${index}] is a sparse array hole`);
+        }
+        visit(candidate[index], `${path}[${index}]`);
+      }
+      for (const key of Reflect.ownKeys(candidate)) {
+        if (key === "length") {
+          continue;
+        }
+        if (typeof key !== "string" || !isArrayIndexKey(key, candidate.length)) {
+          throw new Error(`${path} has unsupported array property ${String(key)}`);
+        }
+      }
+    } else {
+      const prototype = Object.getPrototypeOf(candidate);
+      if (prototype !== Object.prototype && prototype !== null) {
+        throw new Error(`${path} must be a plain object`);
+      }
+      if (Object.getOwnPropertySymbols(candidate).length > 0) {
+        throw new Error(`${path} has unsupported symbol keys`);
+      }
+      for (const key of Object.getOwnPropertyNames(candidate)) {
+        const descriptor = Object.getOwnPropertyDescriptor(candidate, key);
+        if (descriptor && !descriptor.enumerable) {
+          throw new Error(`${path}.${key} must be enumerable`);
+        }
+        visit((candidate as Record<string, unknown>)[key], `${path}.${key}`);
+      }
+    }
+    seen.delete(candidate);
+  };
+
+  try {
+    visit(value, label);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${label} must be JSON serializable: ${message}`);
+  }
+}
+
+function isArrayIndexKey(key: string, length: number): boolean {
+  if (!/^(0|[1-9][0-9]*)$/.test(key)) {
+    return false;
+  }
+  const index = Number(key);
+  return Number.isSafeInteger(index) && index >= 0 && index < length;
+}
+
+function validatePiCamlFlowRuntime(runtime: PiCamlFlowRuntime): void {
+  if (typeof runtime !== "object" || runtime === null) {
+    throw new Error("Pi CamlFlow runtime must be an object");
+  }
+  validateNonEmptyString(runtime.cwd, "Pi CamlFlow runtime cwd");
+  validateNoNulString(runtime.cwd, "Pi CamlFlow runtime cwd");
+  if (typeof runtime.session !== "object" || runtime.session === null) {
+    throw new Error("Pi CamlFlow runtime session must be an object");
+  }
+  if (runtime.session.thinkingLevel !== undefined && typeof runtime.session.thinkingLevel !== "string") {
+    throw new Error("Pi CamlFlow runtime session thinkingLevel must be a string");
+  }
+  if (typeof runtime.services !== "object" || runtime.services === null) {
+    throw new Error("Pi CamlFlow runtime services must be an object");
+  }
+  if (runtime.services.agentDir !== undefined) {
+    validateNonEmptyString(runtime.services.agentDir, "Pi CamlFlow runtime services agentDir");
+    validateNoNulString(runtime.services.agentDir, "Pi CamlFlow runtime services agentDir");
+  }
+  const modelRegistry = runtime.services.modelRegistry;
+  if (
+    typeof modelRegistry !== "object" ||
+    modelRegistry === null ||
+    typeof modelRegistry.getAvailable !== "function" ||
+    typeof modelRegistry.find !== "function" ||
+    typeof modelRegistry.hasConfiguredAuth !== "function"
+  ) {
+    throw new Error(
+      "Pi CamlFlow runtime modelRegistry must provide getAvailable, find, and hasConfiguredAuth",
+    );
+  }
+  if (runtime.session.model) {
+    validatePiModel(runtime.session.model, "Pi CamlFlow runtime session model");
+  }
+}
+
+function validateAgentInitOptions(options: PiCamlFlowAgentInitOptions): void {
+  if (typeof options !== "object" || options === null || Array.isArray(options)) {
+    throw new Error("Pi CamlFlow agent init options must be an object");
+  }
+  if (options.cwd !== undefined) {
+    validateNonEmptyString(options.cwd, "Pi CamlFlow agent cwd");
+    validateNoNulString(options.cwd, "Pi CamlFlow agent cwd");
+  }
+  if (options.id !== undefined) {
+    validateNonEmptyString(options.id, "Pi CamlFlow agent id");
+    validateNoNulString(options.id, "Pi CamlFlow agent id");
+  }
+  if (typeof options.model === "string") {
+    validateNonEmptyString(options.model, "Pi CamlFlow agent model");
+    validateModelReference(options.model, "Pi CamlFlow agent model");
+  } else if (options.model !== undefined) {
+    validatePiModel(options.model, "Pi CamlFlow agent model");
+  }
+  if (options.thinkingLevel !== undefined && typeof options.thinkingLevel !== "string") {
+    throw new Error("Pi CamlFlow agent thinkingLevel must be a string");
+  }
+}
+
+function validatePiModel(model: unknown, label: string): asserts model is PiModel {
+  if (typeof model !== "object" || model === null) {
+    throw new Error(`${label} must be a Pi model object`);
+  }
+  const candidate = model as {
+    provider?: unknown;
+    id?: unknown;
+    name?: unknown;
+    api?: unknown;
+  };
+  const provider = candidate.provider;
+  const id = candidate.id;
+  const name = candidate.name;
+  const api = candidate.api;
+  validateNonEmptyString(provider, `${label} provider`);
+  validateNoNulString(provider, `${label} provider`);
+  validateNonEmptyString(id, `${label} id`);
+  validateNoNulString(id, `${label} id`);
+  validateNonEmptyString(name, `${label} name`);
+  validateNoNulString(name, `${label} name`);
+  validateNonEmptyString(api, `${label} api`);
+  validateNoNulString(api, `${label} api`);
+}
+
+function validateModelReference(value: string, label: string): void {
+  validateNoNulString(value, label);
+  const separatorIndex = value.indexOf("/");
+  if (separatorIndex <= 0 || separatorIndex === value.length - 1) {
+    return;
+  }
+  validateNonEmptyString(value.slice(0, separatorIndex), `${label} provider`);
+  validateNonEmptyString(value.slice(separatorIndex + 1), `${label} id`);
+}
+
+function validateModelAuthResult(value: unknown): asserts value is boolean {
+  if (typeof value !== "boolean") {
+    throw new Error("Pi CamlFlow runtime modelRegistry.hasConfiguredAuth must return a boolean");
+  }
+}
+
 function resolveWorkerModel(
   runtime: PiCamlFlowRuntime,
   request: Pick<PiCamlFlowEffectRequest, "kind" | "name" | "requestedModel">,
@@ -484,18 +2873,43 @@ function resolveWorkerModel(
   }
 
   if (runtime.session.model) {
+    validatePiModel(runtime.session.model, "Pi CamlFlow runtime session model");
     return runtime.session.model;
   }
 
-  const fallback = runtime.services.modelRegistry.getAvailable()[0];
+  const fallback = getAvailableModels(runtime)[0];
   if (fallback) {
+    validatePiModel(fallback, "Pi CamlFlow runtime available model");
     return fallback;
   }
 
   throw new PiCamlFlowMissingModelError(request);
 }
 
+function resolveNamedModel(runtime: PiCamlFlowRuntime, requestedModel: string): PiModel {
+  const model = resolveRequestedModel(runtime, requestedModel);
+  if (!model) {
+    throw new PiCamlFlowMissingModelError({
+      kind: "harness-agent",
+      name: requestedModel,
+    });
+  }
+  return model;
+}
+
+function getAvailableModels(runtime: PiCamlFlowRuntime): PiModel[] {
+  const models = runtime.services.modelRegistry.getAvailable();
+  if (!Array.isArray(models)) {
+    throw new Error("Pi CamlFlow runtime modelRegistry.getAvailable must return an array");
+  }
+  for (const [index, model] of models.entries()) {
+    validatePiModel(model, `Pi CamlFlow runtime available model ${index}`);
+  }
+  return models;
+}
+
 function resolveRequestedModel(runtime: PiCamlFlowRuntime, requestedModel: string): PiModel | undefined {
+  validateModelReference(requestedModel, "Pi CamlFlow requested model");
   const separatorIndex = requestedModel.indexOf("/");
   if (separatorIndex <= 0 || separatorIndex === requestedModel.length - 1) {
     return undefined;
@@ -504,7 +2918,13 @@ function resolveRequestedModel(runtime: PiCamlFlowRuntime, requestedModel: strin
   const provider = requestedModel.slice(0, separatorIndex);
   const modelId = requestedModel.slice(separatorIndex + 1);
   const model = runtime.services.modelRegistry.find(provider, modelId);
-  if (!model || !runtime.services.modelRegistry.hasConfiguredAuth(model)) {
+  if (!model) {
+    return undefined;
+  }
+  validatePiModel(model, "Pi CamlFlow requested model");
+  const hasConfiguredAuth = runtime.services.modelRegistry.hasConfiguredAuth(model);
+  validateModelAuthResult(hasConfiguredAuth);
+  if (!hasConfiguredAuth) {
     return undefined;
   }
   return model;
@@ -512,9 +2932,9 @@ function resolveRequestedModel(runtime: PiCamlFlowRuntime, requestedModel: strin
 
 type AssistantMessageLike = {
   role: "assistant";
-  content: Array<{ type: string; text?: string }>;
-  stopReason?: string;
-  errorMessage?: string;
+  content?: unknown;
+  stopReason?: unknown;
+  errorMessage?: unknown;
 };
 
 function findLastAssistantMessage(messages: readonly unknown[]): AssistantMessageLike | undefined {
@@ -531,17 +2951,43 @@ function isAssistantMessage(value: unknown): value is AssistantMessageLike {
   return (
     typeof value === "object" &&
     value !== null &&
-    (value as { role?: unknown }).role === "assistant" &&
-    Array.isArray((value as { content?: unknown }).content)
+    (value as { role?: unknown }).role === "assistant"
   );
 }
 
+function validateAssistantMessageStatus(message: AssistantMessageLike): void {
+  if (message.stopReason !== undefined && typeof message.stopReason !== "string") {
+    throw new Error("Pi assistant message stopReason must be a string");
+  }
+  if (message.errorMessage !== undefined && typeof message.errorMessage !== "string") {
+    throw new Error("Pi assistant message errorMessage must be a string");
+  }
+}
+
 function extractAssistantText(message: AssistantMessageLike): string {
-  return message.content
-    .filter((content) => content.type === "text" && typeof content.text === "string")
-    .map((content) => content.text)
-    .join("\n")
-    .trim();
+  if (!Array.isArray(message.content)) {
+    throw new Error("Pi assistant message content must be an array");
+  }
+  const texts: string[] = [];
+  for (const [index, content] of message.content.entries()) {
+    const label = `Pi assistant message content[${index}]`;
+    if (typeof content !== "object" || content === null || Array.isArray(content)) {
+      throw new Error(`${label} must be an object`);
+    }
+    if (typeof content.type !== "string") {
+      throw new Error(`${label} type must be a string`);
+    }
+    if (content.type === "text") {
+      if (typeof content.text !== "string") {
+        throw new Error(`${label} text must be a string`);
+      }
+      texts.push(content.text);
+    }
+  }
+  if (texts.length === 0) {
+    throw new Error("Pi assistant message must include text content");
+  }
+  return texts.join("\n").trim();
 }
 
 function extractTextDelta(event: AgentSessionEvent): string | undefined {
@@ -549,14 +2995,20 @@ function extractTextDelta(event: AgentSessionEvent): string | undefined {
     type?: unknown;
     assistantMessageEvent?: { type?: unknown; delta?: unknown };
   };
-  if (
-    candidate.type === "message_update" &&
-    candidate.assistantMessageEvent?.type === "text_delta" &&
-    typeof candidate.assistantMessageEvent.delta === "string"
-  ) {
-    return candidate.assistantMessageEvent.delta;
+  if (candidate.type !== "message_update") {
+    return undefined;
   }
-  return undefined;
+  if (
+    typeof candidate.assistantMessageEvent !== "object" ||
+    candidate.assistantMessageEvent === null ||
+    candidate.assistantMessageEvent.type !== "text_delta"
+  ) {
+    return undefined;
+  }
+  if (typeof candidate.assistantMessageEvent.delta !== "string") {
+    throw new Error("Pi assistant text_delta event delta must be a string");
+  }
+  return candidate.assistantMessageEvent.delta;
 }
 
 function paramsToEffectRequest(params: CamlFlowExecuteEffectParams): PiCamlFlowEffectRequest {
@@ -582,19 +3034,29 @@ function buildEffectStreamId(params: CamlFlowExecuteEffectParams): string {
   return `pi:${step}:${params.effect.kind}:${params.effect.name}`;
 }
 
-function combineAbortSignals(signals: Array<AbortSignal | undefined>): AbortSignal {
+function combineAbortSignals(signals: Array<AbortSignal | undefined>): {
+  signal: AbortSignal;
+  cleanup(): void;
+} {
   const activeSignals = signals.filter((signal): signal is AbortSignal => signal !== undefined);
   if (activeSignals.length === 0) {
-    return new AbortController().signal;
+    return {
+      signal: new AbortController().signal,
+      cleanup: () => undefined,
+    };
   }
   if (activeSignals.length === 1) {
-    return activeSignals[0];
+    return {
+      signal: activeSignals[0],
+      cleanup: () => undefined,
+    };
   }
 
   const controller = new AbortController();
   const abort = (): void => {
     controller.abort();
   };
+  const listeningSignals: AbortSignal[] = [];
 
   for (const signal of activeSignals) {
     if (signal.aborted) {
@@ -602,7 +3064,16 @@ function combineAbortSignals(signals: Array<AbortSignal | undefined>): AbortSign
       break;
     }
     signal.addEventListener("abort", abort, { once: true });
+    listeningSignals.push(signal);
   }
 
-  return controller.signal;
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      for (const signal of listeningSignals) {
+        signal.removeEventListener("abort", abort);
+      }
+      listeningSignals.length = 0;
+    },
+  };
 }

--- a/packages/camlflow-pi-sdk/test/pi-sdk.test.mjs
+++ b/packages/camlflow-pi-sdk/test/pi-sdk.test.mjs
@@ -1,10 +1,15 @@
 import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdtemp, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 import {
   PiCamlFlowEffectExecutor,
   PiCamlFlowMissingModelError,
   buildPiCamlFlowEffectPrompt,
+  createPiCamlFlowHarness,
   createPiCamlFlowHostSession,
   parseCamlFlowJsonOutput,
 } from "../dist/index.js";
@@ -50,6 +55,75 @@ function createEffectRequest(overrides = {}) {
   };
 }
 
+function createExecuteEffectParams(overrides = {}) {
+  const effectOverrides = overrides.effect ?? {};
+  return {
+    runId: "run-1",
+    step: 1,
+    ...overrides,
+    effect: {
+      ...createEffectRequest({
+        declaredReturnType: "record",
+        outputSchema: { type: "object" },
+        workingDirectory: null,
+        skillsDirectory: null,
+        skillMarkdown: null,
+        inlineDefinition: null,
+        requestedModel: null,
+        unsupportedSettings: [],
+        step: 1,
+        runId: "run-1",
+      }),
+      ...effectOverrides,
+    },
+  };
+}
+
+function createLocation(overrides = {}) {
+  return {
+    file: "examples/basic/main.cml",
+    start: { line: 1, column: 0, offset: 0 },
+    end: { line: 1, column: 10, offset: 10 },
+    ...overrides,
+  };
+}
+
+function createInlineDefinition(overrides = {}) {
+  return {
+    model: "faux/model",
+    temperature: null,
+    system_prompt: "Review tersely.",
+    metadata: [
+      { name: "tone", value: { kind: "string", value: "terse" } },
+      { name: "retries", value: { kind: "int", value: 1 } },
+      { name: "enabled", value: { kind: "bool", value: true } },
+      { name: "weight", value: { kind: "float", value: 0.5 } },
+      { name: "marker", value: { kind: "unit" } },
+    ],
+    loc: createLocation(),
+    ...overrides,
+  };
+}
+
+function countAbortSignalListeners(signal) {
+  const originalAdd = signal.addEventListener.bind(signal);
+  const originalRemove = signal.removeEventListener.bind(signal);
+  const counts = { added: 0, removed: 0 };
+  signal.addEventListener = (type, listener, options) => {
+    if (type === "abort") {
+      counts.added += 1;
+    }
+    return originalAdd(type, listener, options);
+  };
+  signal.removeEventListener = (type, listener, options) => {
+    if (type === "abort") {
+      counts.removed += 1;
+    }
+    return originalRemove(type, listener, options);
+  };
+  return counts;
+}
+
 class FakeWorkerSession {
   constructor(outputText) {
     this.outputText = outputText;
@@ -57,6 +131,7 @@ class FakeWorkerSession {
     this.listeners = [];
     this.abortCalled = false;
     this.disposeCalled = false;
+    this.disposeCalls = 0;
     this.promptText = undefined;
     this.promptStarted = new Promise((resolve) => {
       this.resolvePromptStarted = resolve;
@@ -101,10 +176,17 @@ class FakeWorkerSession {
 
   async abort() {
     this.abortCalled = true;
+    if (this.abortError) {
+      throw this.abortError;
+    }
     this.releasePrompt();
   }
 
   dispose() {
+    this.disposeCalls += 1;
+    if (this.disposeError) {
+      throw this.disposeError;
+    }
     this.disposeCalled = true;
   }
 }
@@ -114,6 +196,10 @@ test("parses raw and fenced JSON worker output", () => {
   assert.deepEqual(parseCamlFlowJsonOutput('```json\n{"answer":42}\n```'), {
     answer: 42,
   });
+  assert.throws(
+    () => parseCamlFlowJsonOutput(42),
+    /JSON output must be a string/,
+  );
 });
 
 test("builds a Pi worker prompt from the rendered CamlFlow effect prompt", () => {
@@ -122,6 +208,167 @@ test("builds a Pi worker prompt from the rendered CamlFlow effect prompt", () =>
   assert.match(prompt, /Return exactly one JSON value/);
   assert.match(prompt, /Say hello to Ada\./);
   assert.match(prompt, /Declared return type: string/);
+});
+
+test("rejects invalid CamlFlow effect requests before worker creation", async () => {
+  const circularSchema = {};
+  circularSchema.self = circularSchema;
+  const circularInput = {};
+  circularInput.self = circularInput;
+  const hiddenInput = { visible: true };
+  Object.defineProperty(hiddenInput, "hidden", {
+    value: "secret",
+    enumerable: false,
+  });
+  const symbolInput = { visible: true };
+  symbolInput[Symbol("hidden")] = "secret";
+  const toJsonInput = { visible: true };
+  Object.defineProperty(toJsonInput, "toJSON", {
+    value: () => ({ rewritten: true }),
+    enumerable: false,
+  });
+  const extraArrayInput = ["item"];
+  extraArrayInput.extra = "hidden";
+  const cases = [
+    {
+      request: null,
+      message: /effect request must be an object/,
+    },
+    {
+      request: [],
+      message: /effect request must be an object/,
+    },
+    {
+      request: createEffectRequest({ kind: "" }),
+      message: /effect kind must not be empty/,
+    },
+    {
+      request: createEffectRequest({ kind: "bound-agent\0" }),
+      message: /effect kind must not contain NUL bytes/,
+    },
+    {
+      request: createEffectRequest({ name: " " }),
+      message: /effect name must not be empty/,
+    },
+    {
+      request: createEffectRequest({ name: "greeter\0" }),
+      message: /effect name must not contain NUL bytes/,
+    },
+    {
+      request: createEffectRequest({ renderedPrompt: 42 }),
+      message: /effect renderedPrompt must not be empty/,
+    },
+    {
+      request: createEffectRequest({ workingDirectory: " " }),
+      message: /effect workingDirectory must not be empty/,
+    },
+    {
+      request: createEffectRequest({ workingDirectory: "bad\0cwd" }),
+      message: /effect workingDirectory must not contain NUL bytes/,
+    },
+    {
+      request: createEffectRequest({ skillsDirectory: 42 }),
+      message: /effect skillsDirectory must not be empty/,
+    },
+    {
+      request: createEffectRequest({ skillsDirectory: "bad\0skills" }),
+      message: /effect skillsDirectory must not contain NUL bytes/,
+    },
+    {
+      request: createEffectRequest({ skillMarkdown: "" }),
+      message: /effect skillMarkdown must not be empty/,
+    },
+    {
+      request: createEffectRequest({ requestedModel: "" }),
+      message: /effect requestedModel must not be empty/,
+    },
+    {
+      request: createEffectRequest({ requestedModel: "bad\0model" }),
+      message: /effect requestedModel must not contain NUL bytes/,
+    },
+    {
+      request: createEffectRequest({ declaredReturnType: "" }),
+      message: /effect declaredReturnType must not be empty/,
+    },
+    {
+      request: createEffectRequest({ declaredReturnType: "record\0" }),
+      message: /effect declaredReturnType must not contain NUL bytes/,
+    },
+    {
+      request: createEffectRequest({ runId: " " }),
+      message: /effect runId must not be empty/,
+    },
+    {
+      request: createEffectRequest({ runId: "run\0id" }),
+      message: /effect runId must not contain NUL bytes/,
+    },
+    {
+      request: createEffectRequest({ step: 1.5 }),
+      message: /effect step must be a non-negative integer/,
+    },
+    {
+      request: createEffectRequest({ input: undefined }),
+      message: /effect input must be JSON serializable/,
+    },
+    {
+      request: createEffectRequest({ input: { value: Number.NaN } }),
+      message: /effect input must be JSON serializable/,
+    },
+    {
+      request: createEffectRequest({ input: { value: () => undefined } }),
+      message: /effect input must be JSON serializable/,
+    },
+    {
+      request: createEffectRequest({ input: new Date() }),
+      message: /effect input must be JSON serializable/,
+    },
+    {
+      request: createEffectRequest({ input: [, "hole"] }),
+      message: /effect input must be JSON serializable/,
+    },
+    {
+      request: createEffectRequest({ input: hiddenInput }),
+      message: /effect input must be JSON serializable/,
+    },
+    {
+      request: createEffectRequest({ input: symbolInput }),
+      message: /effect input must be JSON serializable/,
+    },
+    {
+      request: createEffectRequest({ input: toJsonInput }),
+      message: /effect input must be JSON serializable/,
+    },
+    {
+      request: createEffectRequest({ input: extraArrayInput }),
+      message: /effect input must be JSON serializable/,
+    },
+    {
+      request: createEffectRequest({ outputSchema: circularSchema }),
+      message: /effect outputSchema must be JSON serializable/,
+    },
+    {
+      request: createEffectRequest({ outputSchema: [] }),
+      message: /effect outputSchema must be an object/,
+    },
+    {
+      request: createEffectRequest({ input: circularInput }),
+      message: /effect input must be JSON serializable/,
+    },
+  ];
+
+  for (const { request, message } of cases) {
+    let workerCreated = false;
+    const executor = new PiCamlFlowEffectExecutor(createRuntime(), {
+      workerSessionFactory: async () => {
+        workerCreated = true;
+        return new FakeWorkerSession("{}");
+      },
+    });
+
+    assert.throws(() => buildPiCamlFlowEffectPrompt(request), message);
+    await assert.rejects(() => executor.executeEffect(request), message);
+    assert.equal(workerCreated, false);
+  }
 });
 
 test("executes each effect in an injected ephemeral worker session and relays chunks", async () => {
@@ -149,6 +396,57 @@ test("executes each effect in an injected ephemeral worker session and relays ch
   assert.deepEqual(chunks.at(-1), { delta: "", done: true });
 });
 
+test("streaming output chunk failures do not fail effect execution", async () => {
+  const executor = new PiCamlFlowEffectExecutor(createRuntime(), {
+    workerSessionFactory: async () => new FakeWorkerSession('{"answer":"hello Ada"}'),
+  });
+  const doneChunks = [];
+
+  const result = await executor.executeEffect(createEffectRequest(), {
+    emitOutputChunk: (delta, done) => {
+      if (!done && delta.length > 0) {
+        throw new Error("chunk failed");
+      }
+      doneChunks.push({ delta, done });
+    },
+  });
+
+  assert.deepEqual(result, { answer: "hello Ada" });
+  assert.deepEqual(doneChunks, [{ delta: "", done: true }]);
+});
+
+test("rejects malformed worker text delta events", async () => {
+  let session;
+  const executor = new PiCamlFlowEffectExecutor(createRuntime(), {
+    workerSessionFactory: async () => {
+      session = new FakeWorkerSession('{"answer":"unreachable"}');
+      session.prompt = async () => {
+        for (const listener of session.listeners) {
+          listener({
+            type: "message_update",
+            assistantMessageEvent: {
+              type: "text_delta",
+              delta: 42,
+            },
+          });
+        }
+        session.messages.push({
+          role: "assistant",
+          content: [{ type: "text", text: '{"answer":"unreachable"}' }],
+          stopReason: "stop",
+        });
+      };
+      return session;
+    },
+  });
+
+  await assert.rejects(
+    () => executor.executeEffect(createEffectRequest()),
+    /text_delta event delta must be a string/,
+  );
+  assert.equal(session.disposeCalled, true);
+});
+
 test("rejects malformed worker JSON", async () => {
   const executor = new PiCamlFlowEffectExecutor(createRuntime(), {
     workerSessionFactory: async () => new FakeWorkerSession("not json"),
@@ -158,6 +456,116 @@ test("rejects malformed worker JSON", async () => {
     () => executor.executeEffect(createEffectRequest()),
     /CamlFlow effect returned invalid JSON/,
   );
+});
+
+test("rejects malformed worker assistant message content", async () => {
+  const cases = [
+    {
+      content: undefined,
+      message: /assistant message content must be an array/,
+    },
+    {
+      content: { type: "text", text: "{}" },
+      message: /assistant message content must be an array/,
+    },
+    {
+      content: [null],
+      message: /assistant message content\[0\] must be an object/,
+    },
+    {
+      content: [{ text: "{}" }],
+      message: /assistant message content\[0\] type must be a string/,
+    },
+    {
+      content: [{ type: "text", text: 42 }],
+      message: /assistant message content\[0\] text must be a string/,
+    },
+    {
+      content: [{ type: "tool_use", id: "call-1" }],
+      message: /assistant message must include text content/,
+    },
+  ];
+
+  for (const { content, message } of cases) {
+    const executor = new PiCamlFlowEffectExecutor(createRuntime(), {
+      workerSessionFactory: async () => {
+        const session = new FakeWorkerSession("{}");
+        session.prompt = async () => {
+          session.messages.push({
+            role: "assistant",
+            content,
+            stopReason: "stop",
+          });
+        };
+        return session;
+      },
+    });
+
+    await assert.rejects(
+      () => executor.executeEffect(createEffectRequest()),
+      message,
+    );
+  }
+});
+
+test("rejects malformed latest worker assistant message instead of reusing stale output", async () => {
+  const executor = new PiCamlFlowEffectExecutor(createRuntime(), {
+    workerSessionFactory: async () => {
+      const session = new FakeWorkerSession("{}");
+      session.messages.push({
+        role: "assistant",
+        content: [{ type: "text", text: '{"answer":"stale"}' }],
+        stopReason: "stop",
+      });
+      session.prompt = async () => {
+        session.messages.push({
+          role: "assistant",
+          content: "malformed",
+          stopReason: "stop",
+        });
+      };
+      return session;
+    },
+  });
+
+  await assert.rejects(
+    () => executor.executeEffect(createEffectRequest()),
+    /assistant message content must be an array/,
+  );
+});
+
+test("rejects malformed worker assistant message status fields", async () => {
+  const cases = [
+    {
+      status: { stopReason: 42 },
+      message: /assistant message stopReason must be a string/,
+    },
+    {
+      status: { stopReason: "error", errorMessage: { message: "boom" } },
+      message: /assistant message errorMessage must be a string/,
+    },
+  ];
+
+  for (const { status, message } of cases) {
+    const executor = new PiCamlFlowEffectExecutor(createRuntime(), {
+      workerSessionFactory: async () => {
+        const session = new FakeWorkerSession("{}");
+        session.prompt = async () => {
+          session.messages.push({
+            role: "assistant",
+            content: [{ type: "text", text: "{}" }],
+            ...status,
+          });
+        };
+        return session;
+      },
+    });
+
+    await assert.rejects(
+      () => executor.executeEffect(createEffectRequest()),
+      message,
+    );
+  }
 });
 
 test("fails before creating a worker when Pi has no configured model", async () => {
@@ -188,6 +596,368 @@ test("fails before creating a worker when Pi has no configured model", async () 
   assert.equal(workerCreated, false);
 });
 
+test("rejects malformed model registry results before worker creation", async () => {
+  const cases = [
+    {
+      runtime: createRuntime({
+        session: { model: undefined, thinkingLevel: "off" },
+        services: {
+          modelRegistry: {
+            getAvailable: () => null,
+            find: () => undefined,
+            hasConfiguredAuth: () => false,
+          },
+        },
+      }),
+      request: createEffectRequest(),
+      message: /modelRegistry\.getAvailable must return an array/,
+    },
+    {
+      runtime: createRuntime({
+        session: { model: undefined, thinkingLevel: "off" },
+        services: {
+          modelRegistry: {
+            getAvailable: () => [{}],
+            find: () => undefined,
+            hasConfiguredAuth: () => false,
+          },
+        },
+      }),
+      request: createEffectRequest(),
+      message: /available model 0 provider must not be empty/,
+    },
+    {
+      runtime: createRuntime({
+        session: { model: undefined, thinkingLevel: "off" },
+        services: {
+          modelRegistry: {
+            getAvailable: () => [{ ...fakeModel, name: "bad\0name" }],
+            find: () => undefined,
+            hasConfiguredAuth: () => false,
+          },
+        },
+      }),
+      request: createEffectRequest(),
+      message: /available model 0 name must not contain NUL bytes/,
+    },
+    {
+      runtime: createRuntime({
+        session: { model: undefined, thinkingLevel: "off" },
+        services: {
+          modelRegistry: {
+            getAvailable: () => [{ ...fakeModel, api: "bad\0api" }],
+            find: () => undefined,
+            hasConfiguredAuth: () => false,
+          },
+        },
+      }),
+      request: createEffectRequest(),
+      message: /available model 0 api must not contain NUL bytes/,
+    },
+    {
+      runtime: createRuntime({
+        session: { model: undefined, thinkingLevel: "off" },
+        services: {
+          modelRegistry: {
+            getAvailable: () => [],
+            find: () => ({}),
+            hasConfiguredAuth: () => true,
+          },
+        },
+      }),
+      request: createEffectRequest({ requestedModel: "faux/model" }),
+      message: /requested model provider must not be empty/,
+    },
+    {
+      runtime: createRuntime({
+        session: { model: undefined, thinkingLevel: "off" },
+        services: {
+          modelRegistry: {
+            getAvailable: () => [],
+            find: () => fakeModel,
+            hasConfiguredAuth: () => "yes",
+          },
+        },
+      }),
+      request: createEffectRequest({ requestedModel: "faux/model" }),
+      message: /hasConfiguredAuth must return a boolean/,
+    },
+  ];
+
+  for (const { runtime, request, message } of cases) {
+    let workerCreated = false;
+    const executor = new PiCamlFlowEffectExecutor(runtime, {
+      workerSessionFactory: async () => {
+        workerCreated = true;
+        return new FakeWorkerSession("{}");
+      },
+    });
+
+    await assert.rejects(
+      () => executor.executeEffect(request),
+      message,
+    );
+    assert.equal(workerCreated, false);
+  }
+});
+
+test("rejects invalid runtime configuration before worker or client creation", async () => {
+  const cases = [
+    {
+      runtime: null,
+      message: /runtime must be an object/,
+    },
+    {
+      runtime: createRuntime({ cwd: " " }),
+      message: /runtime cwd must not be empty/,
+    },
+    {
+      runtime: createRuntime({ cwd: "/tmp/bad\0cwd" }),
+      message: /runtime cwd must not contain NUL bytes/,
+    },
+    {
+      runtime: createRuntime({ session: null }),
+      message: /runtime session must be an object/,
+    },
+    {
+      runtime: createRuntime({ session: { model: {}, thinkingLevel: "off" } }),
+      message: /runtime session model provider must not be empty/,
+    },
+    {
+      runtime: createRuntime({ session: { model: fakeModel, thinkingLevel: 42 } }),
+      message: /runtime session thinkingLevel must be a string/,
+    },
+    {
+      runtime: createRuntime({ services: null }),
+      message: /runtime services must be an object/,
+    },
+    {
+      runtime: createRuntime({
+        services: {
+          agentDir: " ",
+          modelRegistry: createRuntime().services.modelRegistry,
+        },
+      }),
+      message: /runtime services agentDir must not be empty/,
+    },
+    {
+      runtime: createRuntime({
+        services: {
+          agentDir: "/tmp/bad\0agent-dir",
+          modelRegistry: createRuntime().services.modelRegistry,
+        },
+      }),
+      message: /runtime services agentDir must not contain NUL bytes/,
+    },
+    {
+      runtime: createRuntime({ services: { modelRegistry: {} } }),
+      message: /modelRegistry must provide/,
+    },
+  ];
+
+  for (const { runtime, message } of cases) {
+    assert.throws(
+      () =>
+        new PiCamlFlowEffectExecutor(runtime, {
+          workerSessionFactory: async () => {
+            throw new Error("worker should not be created");
+          },
+        }),
+      message,
+    );
+
+    assert.throws(
+      () =>
+        createPiCamlFlowHostSession({
+          runtime,
+          clientFactory: () => {
+            throw new Error("client should not be created");
+          },
+        }),
+      message,
+    );
+
+    assert.throws(
+      () =>
+        createPiCamlFlowHarness({
+          runtime,
+          workerSessionFactory: async () => {
+            throw new Error("worker should not be created");
+          },
+        }),
+      message,
+    );
+  }
+});
+
+test("rejects malformed exported option bags before worker or client creation", async () => {
+  assert.throws(
+    () => new PiCamlFlowEffectExecutor(createRuntime(), null),
+    /effect executor options must be an object/,
+  );
+  assert.throws(
+    () => new PiCamlFlowEffectExecutor(createRuntime(), []),
+    /effect executor options must be an object/,
+  );
+  assert.throws(
+    () =>
+      new PiCamlFlowEffectExecutor(createRuntime(), {
+        workerSessionFactory: {},
+      }),
+    /workerSessionFactory must be a function/,
+  );
+
+  const executor = new PiCamlFlowEffectExecutor(createRuntime(), {
+    workerSessionFactory: async () => new FakeWorkerSession("{}"),
+  });
+  await assert.rejects(
+    () => executor.executeEffect(createEffectRequest(), null),
+    /effect execution options must be an object/,
+  );
+  await assert.rejects(
+    () => executor.executeEffect(createEffectRequest(), []),
+    /effect execution options must be an object/,
+  );
+  await assert.rejects(
+    () =>
+      executor.executeEffect(createEffectRequest(), {
+        signal: { aborted: false },
+      }),
+    /effect execution signal must be an AbortSignal/,
+  );
+  await assert.rejects(
+    () =>
+      executor.executeEffect(createEffectRequest(), {
+        emitOutputChunk: {},
+      }),
+    /emitOutputChunk must be a function/,
+  );
+
+  assert.throws(
+    () => createPiCamlFlowHostSession(null),
+    /host session options must be an object/,
+  );
+  assert.throws(
+    () => createPiCamlFlowHostSession([]),
+    /host session options must be an object/,
+  );
+  assert.throws(
+    () =>
+      createPiCamlFlowHostSession({
+        runtime: createRuntime(),
+        clientFactory: {},
+      }),
+    /clientFactory must be a function/,
+  );
+  assert.throws(
+    () =>
+      createPiCamlFlowHostSession({
+        runtime: createRuntime(),
+        onTrace: {},
+      }),
+    /onTrace callback must be a function/,
+  );
+  assert.throws(
+    () =>
+      createPiCamlFlowHostSession({
+        runtime: createRuntime(),
+        autoShutdown: "no",
+      }),
+    /autoShutdown must be a boolean/,
+  );
+  const hiddenSpawnEnv = { GOOD: "value" };
+  Object.defineProperty(hiddenSpawnEnv, "HIDDEN", {
+    enumerable: false,
+    value: "secret",
+  });
+  const symbolSpawnEnv = { GOOD: "value" };
+  symbolSpawnEnv[Symbol("SECRET")] = "secret";
+  for (const camlflow of [
+    { command: " " },
+    { command: "bad\0cmd" },
+    { args: "serve" },
+    { args: ["serve", 42] },
+    { args: ["bad\0arg"] },
+    { cwd: " " },
+    { cwd: "bad\0cwd" },
+    { env: [] },
+    { env: new Date() },
+    { env: hiddenSpawnEnv },
+    { env: symbolSpawnEnv },
+    { env: { "BAD=NAME": "value" } },
+    { env: { BAD: "bad\0value" } },
+    { stderr: "ignore" },
+    { onNotification: {} },
+  ]) {
+    assert.throws(
+      () =>
+        createPiCamlFlowHostSession({
+          runtime: createRuntime(),
+          camlflow,
+        }),
+      /camlflow options/,
+    );
+  }
+
+  assert.throws(
+    () => createPiCamlFlowHarness(null),
+    /harness options must be an object/,
+  );
+  assert.throws(
+    () => createPiCamlFlowHarness([]),
+    /harness options must be an object/,
+  );
+  assert.throws(
+    () =>
+      createPiCamlFlowHarness({
+        runtime: createRuntime(),
+        camlflow: "local",
+      }),
+    /harness camlflow options must be an object/,
+  );
+  assert.throws(
+    () =>
+      createPiCamlFlowHarness({
+        runtime: createRuntime(),
+        camlflow: { command: "bad\0cmd" },
+      }),
+    /harness camlflow options command must not contain NUL bytes/,
+  );
+
+  const harness = createPiCamlFlowHarness({ runtime: createRuntime() });
+  await assert.rejects(
+    () => harness.init(null),
+    /agent init options must be an object/,
+  );
+  await assert.rejects(
+    () => harness.init([]),
+    /agent init options must be an object/,
+  );
+});
+
+test("rejects malformed injected worker sessions before prompting", async () => {
+  const workerSession = {
+    messages: [],
+    subscribe() {
+      throw new Error("subscribe should not be called");
+    },
+    abort() {
+      throw new Error("abort should not be called");
+    },
+    dispose() {
+      throw new Error("dispose should not be called");
+    },
+  };
+  const executor = new PiCamlFlowEffectExecutor(createRuntime(), {
+    workerSessionFactory: async () => workerSession,
+  });
+
+  await assert.rejects(
+    () => executor.executeEffect(createEffectRequest()),
+    /effect worker session must provide prompt, subscribe, abort, and dispose/,
+  );
+});
+
 test("cancellation aborts the active worker session", async () => {
   const session = new FakeWorkerSession("{}");
   session.waitForAbort = true;
@@ -204,6 +974,135 @@ test("cancellation aborts the active worker session", async () => {
 
   await assert.rejects(pending, /CamlFlow effect cancelled/);
   assert.equal(session.abortCalled, true);
+  assert.equal(session.disposeCalled, true);
+});
+
+test("cancellation during worker creation disposes the late worker session", async () => {
+  let releaseWorker;
+  let signalWorkerStarted;
+  let lateSession;
+  const workerGate = new Promise((resolve) => {
+    releaseWorker = resolve;
+  });
+  const workerStarted = new Promise((resolve) => {
+    signalWorkerStarted = resolve;
+  });
+  const controller = new AbortController();
+  const executor = new PiCamlFlowEffectExecutor(createRuntime(), {
+    workerSessionFactory: async () => {
+      signalWorkerStarted();
+      await workerGate;
+      lateSession = new FakeWorkerSession("{}");
+      return lateSession;
+    },
+  });
+
+  const pending = executor.executeEffect(createEffectRequest(), {
+    signal: controller.signal,
+  });
+  await workerStarted;
+  controller.abort();
+  releaseWorker();
+
+  await assert.rejects(pending, /CamlFlow effect cancelled/);
+  assert.equal(lateSession.abortCalled, true);
+  assert.equal(lateSession.disposeCalled, true);
+  assert.equal(lateSession.promptText, undefined);
+});
+
+test("worker subscribe failures still dispose the worker session", async () => {
+  const session = new FakeWorkerSession("{}");
+  session.subscribe = () => {
+    throw new Error("subscribe failed");
+  };
+  const executor = new PiCamlFlowEffectExecutor(createRuntime(), {
+    workerSessionFactory: async () => session,
+  });
+
+  await assert.rejects(
+    () => executor.executeEffect(createEffectRequest()),
+    /subscribe failed/,
+  );
+  assert.equal(session.disposeCalled, true);
+});
+
+test("worker subscribe must return an unsubscribe function", async () => {
+  const session = new FakeWorkerSession("{}");
+  session.subscribe = () => undefined;
+  let promptCalled = false;
+  session.prompt = async () => {
+    promptCalled = true;
+  };
+  const executor = new PiCamlFlowEffectExecutor(createRuntime(), {
+    workerSessionFactory: async () => session,
+  });
+
+  await assert.rejects(
+    () => executor.executeEffect(createEffectRequest()),
+    /subscribe must return an unsubscribe function/,
+  );
+  assert.equal(promptCalled, false);
+  assert.equal(session.disposeCalled, true);
+});
+
+test("final output chunk failures still unsubscribe and dispose the worker session", async () => {
+  const session = new FakeWorkerSession('{"answer":"done"}');
+  const executor = new PiCamlFlowEffectExecutor(createRuntime(), {
+    workerSessionFactory: async () => session,
+  });
+
+  await assert.rejects(
+    () =>
+      executor.executeEffect(createEffectRequest(), {
+        emitOutputChunk: (_delta, done) => {
+          if (done) {
+            throw new Error("done failed");
+          }
+        },
+      }),
+    /done failed/,
+  );
+  assert.equal(session.listeners.length, 0);
+  assert.equal(session.disposeCalled, true);
+});
+
+test("primary effect failures are preserved when final output chunk cleanup fails", async () => {
+  const session = new FakeWorkerSession("not json");
+  const executor = new PiCamlFlowEffectExecutor(createRuntime(), {
+    workerSessionFactory: async () => session,
+  });
+
+  await assert.rejects(
+    () =>
+      executor.executeEffect(createEffectRequest(), {
+        emitOutputChunk: (_delta, done) => {
+          if (done) {
+            throw new Error("done failed");
+          }
+        },
+      }),
+    /CamlFlow effect returned invalid JSON/,
+  );
+  assert.equal(session.listeners.length, 0);
+  assert.equal(session.disposeCalled, true);
+});
+
+test("worker cleanup continues when unsubscribe fails", async () => {
+  const session = new FakeWorkerSession('{"answer":"done"}');
+  session.subscribe = (listener) => {
+    session.listeners.push(listener);
+    return () => {
+      throw new Error("unsubscribe failed");
+    };
+  };
+  const executor = new PiCamlFlowEffectExecutor(createRuntime(), {
+    workerSessionFactory: async () => session,
+  });
+
+  await assert.rejects(
+    () => executor.executeEffect(createEffectRequest()),
+    /unsubscribe failed/,
+  );
   assert.equal(session.disposeCalled, true);
 });
 
@@ -242,6 +1141,678 @@ test("host session runs a workflow through the CamlFlow JSON-RPC client factory"
   assert.ok(outputChunks.some((chunk) => chunk.streamId === "pi:1:bound-agent:greeter"));
 });
 
+test("host session rejects malformed JSON-RPC clients before initialize", async () => {
+  let clientCalls = 0;
+  const host = createPiCamlFlowHostSession({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('{"answer":"hello Ada"}'),
+    clientFactory: (options) => {
+      clientCalls += 1;
+      return clientCalls === 1
+        ? { initialize() {} }
+        : new FakeCamlFlowClient(options);
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+      }),
+    /JSON-RPC client must provide initialize, run, and shutdownAndExit/,
+  );
+
+  const result = await host.runWorkflow({
+    workflowPath: "examples/basic/main.cml",
+  });
+  assert.equal(result.runId, "run-1");
+  assert.equal(clientCalls, 2);
+});
+
+test("host session rejects malformed JSON-RPC initialize results before run", async () => {
+  const invalidResults = [
+    null,
+    {
+      protocolVersion: "",
+      irVersion: "0.1.0",
+      capabilities: {},
+      effectKinds: [],
+    },
+    {
+      protocolVersion: "0.1.0",
+      irVersion: "0.1.0",
+      capabilities: null,
+      effectKinds: [],
+    },
+    {
+      protocolVersion: "0.1.0",
+      irVersion: "0.1.0",
+      capabilities: {},
+      effectKinds: [],
+    },
+    {
+      protocolVersion: "0.1.0",
+      irVersion: "0.1.0",
+      capabilities: {
+        check: true,
+        compile: true,
+        run: true,
+        executeEffect: "yes",
+        trace: true,
+        diagnostic: true,
+        progress: true,
+        streaming: true,
+        cancelRequest: true,
+        renderedPrompt: true,
+        outputSchema: true,
+      },
+      effectKinds: [],
+    },
+    {
+      protocolVersion: "0.1.0",
+      irVersion: "0.1.0",
+      capabilities: createCamlFlowCapabilities(),
+      effectKinds: ["unknown-effect"],
+    },
+    {
+      protocolVersion: "0.1.0",
+      irVersion: "0.1.0",
+      capabilities: createCamlFlowCapabilities(),
+      effectKinds: [],
+      helper: () => undefined,
+    },
+    (() => {
+      const result = {
+        protocolVersion: "0.1.0",
+        irVersion: "0.1.0",
+        capabilities: createCamlFlowCapabilities(),
+        effectKinds: [],
+      };
+      Object.defineProperty(result, "hidden", {
+        enumerable: false,
+        value: "not JSON-RPC",
+      });
+      return result;
+    })(),
+  ];
+
+  for (const initializeResult of invalidResults) {
+    let fakeClient;
+    const host = createPiCamlFlowHostSession({
+      runtime: createRuntime(),
+      workerSessionFactory: async () => new FakeWorkerSession('{"answer":"hello Ada"}'),
+      clientFactory: (options) => {
+        fakeClient = new FakeCamlFlowClient(options);
+        fakeClient.initialize = async () => {
+          fakeClient.initializeCalled = true;
+          return initializeResult;
+        };
+        return fakeClient;
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        host.runWorkflow({
+          workflowPath: "examples/basic/main.cml",
+        }),
+      /JSON-RPC initialize result/,
+    );
+    assert.equal(fakeClient.initializeCalled, true);
+    assert.equal(fakeClient.runCalled, false);
+    assert.equal(fakeClient.shutdownCalled, true);
+  }
+});
+
+test("host session rejects malformed JSON-RPC run results after shutdown", async () => {
+  const invalidResults = [
+    null,
+    {
+      runId: "",
+      stepsRun: 1,
+      output: {},
+    },
+    {
+      runId: "run-1",
+      stepsRun: -1,
+      output: {},
+    },
+    {
+      runId: "run-1",
+      stepsRun: 1,
+      output: Number.NaN,
+    },
+    {
+      runId: "run-1",
+      stepsRun: 1,
+      output: {},
+      helper: () => undefined,
+    },
+    (() => {
+      const result = {
+        runId: "run-1",
+        stepsRun: 1,
+        output: {},
+      };
+      result[Symbol("metadata")] = "not JSON-RPC";
+      return result;
+    })(),
+  ];
+
+  for (const runResult of invalidResults) {
+    let fakeClient;
+    const host = createPiCamlFlowHostSession({
+      runtime: createRuntime(),
+      workerSessionFactory: async () => new FakeWorkerSession('{"answer":"hello Ada"}'),
+      clientFactory: (options) => {
+        fakeClient = new FakeCamlFlowClient(options);
+        fakeClient.run = async () => {
+          fakeClient.runCalled = true;
+          return runResult;
+        };
+        return fakeClient;
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        host.runWorkflow({
+          workflowPath: "examples/basic/main.cml",
+        }),
+      /JSON-RPC run result/,
+    );
+    assert.equal(fakeClient.initializeCalled, true);
+    assert.equal(fakeClient.runCalled, true);
+    assert.equal(fakeClient.shutdownCalled, true);
+  }
+});
+
+test("host session validates JSON-RPC notifications before host callbacks", async () => {
+  let spawnOptions;
+  let traceCalls = 0;
+  let diagnosticCalls = 0;
+  let progressCalls = 0;
+  let outputChunkCalls = 0;
+  let lastTrace;
+  const host = createPiCamlFlowHostSession({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('{"answer":"hello Ada"}'),
+    onTrace: async (trace) => {
+      traceCalls += 1;
+      lastTrace = trace;
+    },
+    onDiagnostic: async () => {
+      diagnosticCalls += 1;
+    },
+    onProgress: async () => {
+      progressCalls += 1;
+    },
+    onOutputChunk: async () => {
+      outputChunkCalls += 1;
+    },
+    clientFactory: (options) => {
+      spawnOptions = options;
+      return new FakeCamlFlowClient(options);
+    },
+  });
+
+  await host.runWorkflow({
+    workflowPath: "examples/basic/main.cml",
+  });
+  const validOutputChunkCalls = outputChunkCalls;
+  assert.ok(validOutputChunkCalls > 0);
+
+  const trace = createTraceNotification();
+  await spawnOptions.onTrace(trace, createJsonRpcNotification("camlflow/trace", trace));
+  assert.equal(traceCalls, 1);
+  assert.equal(lastTrace.runId, "run-1");
+
+  const envelopeTrace = createTraceNotification({ runId: "envelope-run" });
+  await spawnOptions.onTrace(
+    createTraceNotification({ runId: "argument-run" }),
+    createJsonRpcNotification("camlflow/trace", envelopeTrace),
+  );
+  assert.equal(traceCalls, 2);
+  assert.equal(lastTrace.runId, "envelope-run");
+
+  await assert.rejects(
+    () =>
+      spawnOptions.onTrace(
+        { ...createTraceNotification(), event: "unknown" },
+        createJsonRpcNotification("camlflow/trace", createTraceNotification()),
+      ),
+    /trace params event/,
+  );
+  await assert.rejects(
+    () =>
+      spawnOptions.onTrace(
+        createTraceNotification(),
+        createJsonRpcNotification("wrong/method", createTraceNotification()),
+      ),
+    /method must be camlflow\/trace/,
+  );
+  await assert.rejects(
+    () =>
+      spawnOptions.onTrace(
+        createTraceNotification(),
+        createJsonRpcNotification("camlflow/trace", {
+          ...createTraceNotification(),
+          step: -1,
+        }),
+      ),
+    /trace params step/,
+  );
+
+  await assert.rejects(
+    () =>
+      spawnOptions.onDiagnostic(
+        { ...createDiagnosticNotification(), severity: "warning" },
+        createJsonRpcNotification(
+          "camlflow/diagnostic",
+          createDiagnosticNotification(),
+        ),
+      ),
+    /diagnostic params severity/,
+  );
+  await assert.rejects(
+    () =>
+      spawnOptions.onDiagnostic(createDiagnosticNotification(), {
+        jsonrpc: "2.0",
+        method: "camlflow/diagnostic",
+      }),
+    /diagnostic notification params must be present/,
+  );
+  assert.equal(diagnosticCalls, 0);
+
+  await assert.rejects(
+    () =>
+      spawnOptions.onProgress(
+        { ...createProgressNotification(), cancellable: "yes" },
+        createJsonRpcNotification("camlflow/progress", createProgressNotification()),
+      ),
+    /progress params cancellable/,
+  );
+  await assert.rejects(
+    () =>
+      spawnOptions.onProgress(
+        createProgressNotification(),
+        createJsonRpcNotification("camlflow/progress", {
+          ...createProgressNotification(),
+          knownSteps: -1,
+        }),
+      ),
+    /progress params knownSteps/,
+  );
+  assert.equal(progressCalls, 0);
+
+  await assert.rejects(
+    () =>
+      spawnOptions.onOutputChunk(
+        { ...createOutputChunkNotification(), done: "yes" },
+        createJsonRpcNotification("camlflow/outputChunk", createOutputChunkNotification()),
+    ),
+    /outputChunk params done/,
+  );
+  await assert.rejects(
+    () =>
+      spawnOptions.onOutputChunk(
+        createOutputChunkNotification(),
+        createJsonRpcNotification("camlflow/outputChunk", {
+          ...createOutputChunkNotification(),
+          streamId: "",
+        }),
+      ),
+    /outputChunk params streamId/,
+  );
+  assert.equal(outputChunkCalls, validOutputChunkCalls);
+});
+
+test("host session validates executeEffect params before worker creation", async () => {
+  const paramsWithHiddenProperty = createExecuteEffectParams();
+  Object.defineProperty(paramsWithHiddenProperty, "hidden", {
+    enumerable: false,
+    value: "not json-rpc",
+  });
+  const cases = [
+    null,
+    {
+      runId: "run-1",
+      step: 1,
+    },
+    createExecuteEffectParams({ step: -1 }),
+    createExecuteEffectParams({ effect: { kind: "unknown-effect" } }),
+    createExecuteEffectParams({ effect: { role: "tool" } }),
+    createExecuteEffectParams({ effect: { name: "greeter\0" } }),
+    createExecuteEffectParams({ effect: { declaredReturnType: "record\0" } }),
+    createExecuteEffectParams({ effect: { kind: "bound-agent", role: "skill" } }),
+    createExecuteEffectParams({ effect: { kind: "bound-skill", role: "agent" } }),
+    createExecuteEffectParams({
+      effect: { kind: "local-prompt-skill", role: "agent" },
+    }),
+    createExecuteEffectParams({
+      effect: {
+        kind: "inline-agent",
+        role: "skill",
+        inlineDefinition: createInlineDefinition(),
+      },
+    }),
+    createExecuteEffectParams({ effect: { runId: "other-run" } }),
+    createExecuteEffectParams({ effect: { step: 2 } }),
+    createExecuteEffectParams({ effect: { unsupportedSettings: "temperature" } }),
+    createExecuteEffectParams({ effect: { unsupportedSettings: [""] } }),
+    createExecuteEffectParams({ effect: { inlineDefinition: [] } }),
+    createExecuteEffectParams({ effect: { kind: "inline-agent", inlineDefinition: null } }),
+    createExecuteEffectParams({
+      effect: { kind: "bound-agent", inlineDefinition: createInlineDefinition() },
+    }),
+    createExecuteEffectParams({
+      effect: { inlineDefinition: createInlineDefinition({ model: 42 }) },
+    }),
+    createExecuteEffectParams({
+      effect: { inlineDefinition: createInlineDefinition({ temperature: "warm" }) },
+    }),
+    createExecuteEffectParams({
+      effect: { inlineDefinition: createInlineDefinition({ system_prompt: 42 }) },
+    }),
+    createExecuteEffectParams({
+      effect: { inlineDefinition: createInlineDefinition({ metadata: "tone" }) },
+    }),
+    createExecuteEffectParams({
+      effect: {
+        inlineDefinition: createInlineDefinition({
+          metadata: [{ name: "", value: { kind: "unit" } }],
+        }),
+      },
+    }),
+    createExecuteEffectParams({
+      effect: {
+        inlineDefinition: createInlineDefinition({
+          metadata: [{ name: "tone\0", value: { kind: "unit" } }],
+        }),
+      },
+    }),
+    createExecuteEffectParams({
+      effect: {
+        inlineDefinition: createInlineDefinition({
+          metadata: [{ name: "tone", value: { kind: "list", value: [] } }],
+        }),
+      },
+    }),
+    createExecuteEffectParams({
+      effect: {
+        inlineDefinition: createInlineDefinition({
+          metadata: [{ name: "tries", value: { kind: "int", value: 1.2 } }],
+        }),
+      },
+    }),
+    createExecuteEffectParams({
+      effect: {
+        inlineDefinition: createInlineDefinition({
+          metadata: [{ name: "marker", value: { kind: "unit", value: null } }],
+        }),
+      },
+    }),
+    createExecuteEffectParams({
+      effect: { inlineDefinition: createInlineDefinition({ loc: { file: "x" } }) },
+    }),
+    createExecuteEffectParams({
+      effect: {
+        inlineDefinition: createInlineDefinition({
+          loc: createLocation({ start: { line: -1, column: 0, offset: 0 } }),
+        }),
+      },
+    }),
+    createExecuteEffectParams({
+      effect: {
+        inlineDefinition: createInlineDefinition({
+          loc: createLocation({ file: "bad\0file.cml" }),
+        }),
+      },
+    }),
+    createExecuteEffectParams({ effect: { outputSchema: [] } }),
+    createExecuteEffectParams({ effect: { renderedPrompt: "" } }),
+    createExecuteEffectParams({ effect: { input: Number.NaN } }),
+    paramsWithHiddenProperty,
+  ];
+
+  for (const params of cases) {
+    let fakeClient;
+    let workerCreated = false;
+    const host = createPiCamlFlowHostSession({
+      runtime: createRuntime(),
+      workerSessionFactory: async () => {
+        workerCreated = true;
+        return new FakeWorkerSession('{"answer":"unreachable"}');
+      },
+      clientFactory: (options) => {
+        fakeClient = new FakeCamlFlowClient(options);
+        fakeClient.run = async (_runParams, runOptions) => {
+          fakeClient.runCalled = true;
+          await fakeClient.options.effectHandler(
+            params,
+            {
+              jsonrpc: "2.0",
+              id: 1,
+              method: "camlflow/executeEffect",
+              params,
+            },
+            {
+              emitOutputChunk: async () => undefined,
+            },
+          );
+          return {
+            runId: "run-1",
+            stepsRun: 1,
+            output: {},
+          };
+        };
+        return fakeClient;
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        host.runWorkflow({
+          workflowPath: "examples/basic/main.cml",
+        }),
+      /executeEffect request|executeEffect params|effect name|effect declaredReturnType|effect renderedPrompt|effect input|effect outputSchema|metadata must match|unsupportedSettings/,
+    );
+    assert.equal(fakeClient.runCalled, true);
+    assert.equal(workerCreated, false);
+    assert.equal(fakeClient.shutdownCalled, true);
+  }
+});
+
+test("host session validates executeEffect request ids before worker creation", async () => {
+  let fakeClient;
+  let workerCreated = false;
+  const host = createPiCamlFlowHostSession({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => {
+      workerCreated = true;
+      return new FakeWorkerSession('{"answer":"unreachable"}');
+    },
+    clientFactory: (options) => {
+      fakeClient = new FakeCamlFlowClient(options);
+      fakeClient.run = async () => {
+        await fakeClient.options.effectHandler(
+          createExecuteEffectParams(),
+          {
+            jsonrpc: "2.0",
+            id: 1.5,
+            method: "camlflow/executeEffect",
+            params: createExecuteEffectParams(),
+          },
+          {
+            emitOutputChunk: async () => undefined,
+          },
+        );
+        return {
+          runId: "run-1",
+          stepsRun: 1,
+          output: {},
+        };
+      };
+      return fakeClient;
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+      }),
+    /executeEffect request id must be a string or integer number/,
+  );
+  assert.equal(workerCreated, false);
+  assert.equal(fakeClient.shutdownCalled, true);
+});
+
+test("host session accepts shaped inline executeEffect definitions", async () => {
+  let workerCreated = false;
+  const host = createPiCamlFlowHostSession({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => {
+      workerCreated = true;
+      return new FakeWorkerSession('{"answer":"inline ok"}');
+    },
+    clientFactory: (options) => {
+      const fakeClient = new FakeCamlFlowClient(options);
+      fakeClient.run = async () => {
+        const effectResult = await fakeClient.options.effectHandler(
+          createExecuteEffectParams({
+            effect: {
+              kind: "inline-agent",
+              inlineDefinition: createInlineDefinition(),
+            },
+          }),
+          {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "camlflow/executeEffect",
+            params: createExecuteEffectParams({
+              effect: {
+                kind: "inline-agent",
+                inlineDefinition: createInlineDefinition(),
+              },
+            }),
+          },
+          {
+            emitOutputChunk: async () => undefined,
+          },
+        );
+        return {
+          runId: "run-1",
+          stepsRun: 1,
+          output: effectResult.output,
+        };
+      };
+      return fakeClient;
+    },
+  });
+
+  const result = await host.runWorkflow({
+    workflowPath: "examples/basic/main.cml",
+  });
+
+  assert.equal(workerCreated, true);
+  assert.deepEqual(result.output, { answer: "inline ok" });
+});
+
+test("host session uses executeEffect request params over injected callback args", async () => {
+  let workerInput;
+  const host = createPiCamlFlowHostSession({
+    runtime: createRuntime(),
+    workerSessionFactory: async (request) => {
+      workerInput = request.input;
+      return new FakeWorkerSession('{"answer":"from envelope"}');
+    },
+    clientFactory: (options) => {
+      const fakeClient = new FakeCamlFlowClient(options);
+      fakeClient.run = async () => {
+        const effectResult = await fakeClient.options.effectHandler(
+          createExecuteEffectParams({
+            effect: {
+              input: { source: "argument" },
+            },
+          }),
+          {
+            jsonrpc: "2.0",
+            id: "run-effect-1",
+            method: "camlflow/executeEffect",
+            params: createExecuteEffectParams({
+              effect: {
+                input: { source: "envelope" },
+              },
+            }),
+          },
+          {
+            emitOutputChunk: async () => undefined,
+          },
+        );
+        return {
+          runId: "run-1",
+          stepsRun: 1,
+          output: effectResult.output,
+        };
+      };
+      return fakeClient;
+    },
+  });
+
+  const result = await host.runWorkflow({
+    workflowPath: "examples/basic/main.cml",
+  });
+
+  assert.deepEqual(workerInput, { source: "envelope" });
+  assert.deepEqual(result.output, { answer: "from envelope" });
+});
+
+test("host session validates executeEffect context before worker creation", async () => {
+  for (const context of [null, {}, { emitOutputChunk: {} }]) {
+    let fakeClient;
+    let workerCreated = false;
+    const host = createPiCamlFlowHostSession({
+      runtime: createRuntime(),
+      workerSessionFactory: async () => {
+        workerCreated = true;
+        return new FakeWorkerSession('{"answer":"unreachable"}');
+      },
+      clientFactory: (options) => {
+        fakeClient = new FakeCamlFlowClient(options);
+        fakeClient.run = async () => {
+          await fakeClient.options.effectHandler(
+            createExecuteEffectParams(),
+            {
+              jsonrpc: "2.0",
+              id: 1,
+              method: "camlflow/executeEffect",
+              params: createExecuteEffectParams(),
+            },
+            context,
+          );
+          return {
+            runId: "run-1",
+            stepsRun: 1,
+            output: {},
+          };
+        };
+        return fakeClient;
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        host.runWorkflow({
+          workflowPath: "examples/basic/main.cml",
+        }),
+      /executeEffect context must provide emitOutputChunk/,
+    );
+    assert.equal(workerCreated, false);
+    assert.equal(fakeClient.shutdownCalled, true);
+  }
+});
+
 test("host session cancel aborts the in-flight JSON-RPC run signal", async () => {
   let fakeClient;
   const host = createPiCamlFlowHostSession({
@@ -264,7 +1835,2411 @@ test("host session cancel aborts the in-flight JSON-RPC run signal", async () =>
   assert.equal(fakeClient.shutdownCalled, true);
 });
 
-test("package exports no slash-command parser", () => {
+test("host session rejects empty workflow paths before spawning a client", async () => {
+  let clientCreated = false;
+  const host = createPiCamlFlowHostSession({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("{}"),
+    clientFactory: (options) => {
+      clientCreated = true;
+      return new FakeCamlFlowClient(options);
+    },
+  });
+
+  await assert.rejects(
+    () => host.runWorkflow({ workflowPath: " \n\t " }),
+    /workflowPath must not be empty/,
+  );
+  await assert.rejects(
+    () => host.runWorkflow({}),
+    /workflowPath must not be empty/,
+  );
+  assert.equal(clientCreated, false);
+});
+
+test("host session rejects empty workflow path options before spawning a client", async () => {
+  let clientCreated = false;
+  const host = createPiCamlFlowHostSession({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("{}"),
+    clientFactory: (options) => {
+      clientCreated = true;
+      return new FakeCamlFlowClient(options);
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        entrypoint: "\t",
+      }),
+    /entrypoint must not be empty/,
+  );
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        entrypoint: 42,
+      }),
+    /entrypoint must not be empty/,
+  );
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        skillsDir: " ",
+      }),
+    /skillsDir must not be empty/,
+  );
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        skillsDir: 42,
+      }),
+    /skillsDir must not be empty/,
+  );
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        includePaths: ["lib", "\n"],
+      }),
+    /includePaths must not contain empty paths/,
+  );
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        includePaths: "lib",
+      }),
+    /includePaths must be an array/,
+  );
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        includePaths: ["lib", 42],
+      }),
+    /includePaths must not contain empty paths/,
+  );
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "bad\0workflow.cml",
+      }),
+    /workflowPath must not contain NUL bytes/,
+  );
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        entrypoint: "bad\0entry",
+      }),
+    /entrypoint must not contain NUL bytes/,
+  );
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        skillsDir: "bad\0skills",
+      }),
+    /skillsDir must not contain NUL bytes/,
+  );
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        includePaths: ["bad\0include"],
+      }),
+    /includePaths entry must not contain NUL bytes/,
+  );
+  await assert.rejects(
+    () => host.runWorkflow(null),
+    /workflow options must be an object/,
+  );
+  await assert.rejects(
+    () => host.runWorkflow([]),
+    /workflow options must be an object/,
+  );
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        signal: { aborted: false },
+      }),
+    /workflow signal must be an AbortSignal/,
+  );
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        input: { value: Number.POSITIVE_INFINITY },
+      }),
+    /workflow input must be JSON serializable/,
+  );
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        input: new Map(),
+      }),
+    /workflow input must be JSON serializable/,
+  );
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        input: Object.defineProperty({ visible: true }, "hidden", {
+          value: true,
+          enumerable: false,
+        }),
+      }),
+    /workflow input must be JSON serializable/,
+  );
+  assert.equal(clientCreated, false);
+});
+
+test("host session rejects pre-aborted workflow signals before spawning a client", async () => {
+  let clientCreated = false;
+  const controller = new AbortController();
+  controller.abort();
+  const host = createPiCamlFlowHostSession({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("{}"),
+    clientFactory: (options) => {
+      clientCreated = true;
+      return new FakeCamlFlowClient(options);
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        signal: controller.signal,
+      }),
+    /CamlFlow effect cancelled/,
+  );
+  assert.equal(clientCreated, false);
+});
+
+test("host session rejects signals aborted during client creation before initialize", async () => {
+  const controller = new AbortController();
+  let fakeClient;
+  const host = createPiCamlFlowHostSession({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("{}"),
+    clientFactory: (options) => {
+      fakeClient = new FakeCamlFlowClient(options);
+      controller.abort();
+      return fakeClient;
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        signal: controller.signal,
+      }),
+    /CamlFlow effect cancelled/,
+  );
+  assert.equal(fakeClient.initializeCalled, false);
+  assert.equal(fakeClient.runCalled, false);
+  assert.equal(fakeClient.shutdownCalled, true);
+});
+
+test("host session removes external abort listeners after workflow completion", async () => {
+  const controller = new AbortController();
+  const abortListeners = countAbortSignalListeners(controller.signal);
+  const host = createPiCamlFlowHostSession({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('{"answer":"hello"}'),
+    clientFactory: (options) => new FakeCamlFlowClient(options),
+  });
+
+  await host.runWorkflow({
+    workflowPath: "examples/basic/main.cml",
+    signal: controller.signal,
+  });
+
+  assert.equal(abortListeners.added, 1);
+  assert.equal(abortListeners.removed, 1);
+});
+
+test("host session clears active runs and shuts down when abort listener cleanup fails", async () => {
+  const controller = new AbortController();
+  controller.signal.removeEventListener = () => {
+    throw new Error("remove listener failed");
+  };
+  const clients = [];
+  const host = createPiCamlFlowHostSession({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('{"answer":"hello"}'),
+    clientFactory: (options) => {
+      const client = new FakeCamlFlowClient(options);
+      clients.push(client);
+      return client;
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+        signal: controller.signal,
+      }),
+    /remove listener failed/,
+  );
+  assert.equal(clients[0].shutdownCalled, true);
+
+  const result = await host.runWorkflow({
+    workflowPath: "examples/basic/main.cml",
+  });
+
+  assert.deepEqual(result.output, { answer: "hello" });
+  assert.equal(clients.length, 2);
+  assert.equal(clients[1].shutdownCalled, true);
+});
+
+test("host session reports shutdown failures after successful workflow runs", async () => {
+  let fakeClient;
+  let clientCalls = 0;
+  const host = createPiCamlFlowHostSession({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('{"answer":"hello"}'),
+    clientFactory: (options) => {
+      clientCalls += 1;
+      fakeClient = new FakeCamlFlowClient(options);
+      if (clientCalls === 1) {
+        fakeClient.shutdownError = new Error("shutdown failed");
+      }
+      return fakeClient;
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+      }),
+    /shutdown failed/,
+  );
+  assert.equal(fakeClient.shutdownCalled, true);
+
+  const result = await host.runWorkflow({
+    workflowPath: "examples/basic/main.cml",
+  });
+
+  assert.deepEqual(result.output, { answer: "hello" });
+});
+
+test("host session preserves run failures when shutdown also fails", async () => {
+  let fakeClient;
+  const host = createPiCamlFlowHostSession({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("not json"),
+    clientFactory: (options) => {
+      fakeClient = new FakeCamlFlowClient(options);
+      fakeClient.shutdownError = new Error("shutdown failed");
+      return fakeClient;
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      host.runWorkflow({
+        workflowPath: "examples/basic/main.cml",
+      }),
+    /CamlFlow effect returned invalid JSON/,
+  );
+  assert.equal(fakeClient.shutdownCalled, true);
+});
+
+test("host session honors autoShutdown false after successful workflow runs", async () => {
+  let fakeClient;
+  const host = createPiCamlFlowHostSession({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('{"answer":"hello"}'),
+    autoShutdown: false,
+    clientFactory: (options) => {
+      fakeClient = new FakeCamlFlowClient(options);
+      return fakeClient;
+    },
+  });
+
+  const result = await host.runWorkflow({
+    workflowPath: "examples/basic/main.cml",
+  });
+
+  assert.deepEqual(result.output, { answer: "hello" });
+  assert.equal(fakeClient.shutdownCalled, false);
+});
+
+test("host session cancel suppresses shutdown failures while aborting the run", async () => {
+  let fakeClient;
+  const host = createPiCamlFlowHostSession({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("{}"),
+    clientFactory: (options) => {
+      fakeClient = new HangingCamlFlowClient(options);
+      fakeClient.shutdownError = new Error("shutdown failed");
+      return fakeClient;
+    },
+  });
+
+  const pending = host.runWorkflow({
+    workflowPath: "examples/basic/main.cml",
+  });
+  await fakeClient.runStarted;
+
+  await host.cancel();
+
+  await assert.rejects(pending, /cancelled/);
+  assert.equal(fakeClient.runSignal.aborted, true);
+  assert.equal(fakeClient.shutdownCalled, true);
+});
+
+test("host session cancel is idempotent while a run is still settling", async () => {
+  let fakeClient;
+  const host = createPiCamlFlowHostSession({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("{}"),
+    clientFactory: (options) => {
+      fakeClient = new HangingCamlFlowClient(options);
+      return fakeClient;
+    },
+  });
+
+  const pending = host.runWorkflow({
+    workflowPath: "examples/basic/main.cml",
+  });
+  await fakeClient.runStarted;
+
+  await host.cancel();
+  await host.cancel();
+
+  await assert.rejects(pending, /cancelled/);
+  assert.equal(fakeClient.shutdownCalls, 2);
+});
+
+test("Flue-style harness prompt returns text or parsed JSON from a Pi session", async () => {
+  const prompts = [];
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => {
+      const session = new FakeWorkerSession('{"translation":"salut","confidence":"high"}');
+      const originalPrompt = session.prompt.bind(session);
+      session.prompt = async (text, options) => {
+        prompts.push({ text, options });
+        await originalPrompt(text, options);
+      };
+      return session;
+    },
+  });
+
+  const agent = await harness.init({ id: "hello", sandbox: "local" });
+  const session = await agent.session("session-1");
+  const result = await session.prompt("Translate hello.", { result: "json" });
+  await session.close();
+
+  assert.deepEqual(result, { translation: "salut", confidence: "high" });
+  assert.equal(agent.id, "hello");
+  assert.equal(session.id, "hello:session-1");
+  assert.equal(prompts[0].text, "Translate hello.");
+  assert.equal(prompts[0].options.expandPromptTemplates, true);
+});
+
+test("Flue-style harness validates init cwd, id, and named model options", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"unreachable"'),
+  });
+
+  await assert.rejects(
+    () => harness.init({ cwd: " " }),
+    /agent cwd must not be empty/,
+  );
+  await assert.rejects(
+    () => harness.init({ cwd: "bad\0cwd" }),
+    /agent cwd must not contain NUL bytes/,
+  );
+  await assert.rejects(
+    () => harness.init({ id: "\n" }),
+    /agent id must not be empty/,
+  );
+  await assert.rejects(
+    () => harness.init({ id: "bad\0id" }),
+    /agent id must not contain NUL bytes/,
+  );
+  await assert.rejects(
+    () => harness.init({ model: " " }),
+    /agent model must not be empty/,
+  );
+  await assert.rejects(
+    () => harness.init({ model: "bad\0model" }),
+    /agent model must not contain NUL bytes/,
+  );
+  await assert.rejects(
+    () => harness.init({ model: {} }),
+    /agent model provider must not be empty/,
+  );
+  await assert.rejects(
+    () => harness.init({ thinkingLevel: 42 }),
+    /agent thinkingLevel must be a string/,
+  );
+  await assert.rejects(
+    () => harness.init({ model: "faux/missing" }),
+    PiCamlFlowMissingModelError,
+  );
+
+  const agent = await harness.init({ model: "faux/model" });
+  const session = await agent.session();
+  await session.close();
+  await agent.close();
+});
+
+test("Flue-style harness rejects malformed injected worker sessions", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => ({
+      prompt: async () => undefined,
+      subscribe: () => () => undefined,
+      abort: async () => undefined,
+      dispose: () => undefined,
+    }),
+  });
+
+  const agent = await harness.init();
+  await assert.rejects(
+    () => agent.session(),
+    /harness worker session must provide a messages array/,
+  );
+  await agent.close();
+});
+
+test("Flue-style harness skill call expands to a Pi skill command with JSON args", async () => {
+  let promptText = "";
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => {
+      const session = new FakeWorkerSession('"done"');
+      const originalPrompt = session.prompt.bind(session);
+      session.prompt = async (text, options) => {
+        promptText = text;
+        await originalPrompt(text, options);
+      };
+      return session;
+    },
+  });
+
+  const agent = await harness.init();
+  const session = await agent.session();
+  const result = await session.skill("triage", {
+    args: { issueNumber: 42 },
+    result: "json",
+  });
+  await session.close();
+
+  assert.equal(result, "done");
+  assert.match(promptText, /^\/skill:triage /);
+  assert.match(promptText, /"issueNumber": 42/);
+});
+
+test("Flue-style harness rejects non-serializable skill args before prompting", async () => {
+  const circularArgs = {};
+  circularArgs.self = circularArgs;
+  let promptCalled = false;
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => {
+      const session = new FakeWorkerSession('"unreachable"');
+      session.prompt = async () => {
+        promptCalled = true;
+      };
+      return session;
+    },
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  await assert.rejects(
+    () => session.skill("triage", { args: circularArgs }),
+    /Pi skill args must be JSON serializable/,
+  );
+  await assert.rejects(
+    () => session.skill("triage", { args: { value: Number.NaN } }),
+    /Pi skill args must be JSON serializable/,
+  );
+  await assert.rejects(
+    () => session.skill("triage", { args: { value: () => undefined } }),
+    /Pi skill args must be JSON serializable/,
+  );
+  await assert.rejects(
+    () => session.skill("triage", { args: [, "hole"] }),
+    /Pi skill args must be JSON serializable/,
+  );
+  const extraArrayArgs = ["item"];
+  extraArrayArgs.extra = "hidden";
+  await assert.rejects(
+    () => session.skill("triage", { args: extraArrayArgs }),
+    /Pi skill args must be JSON serializable/,
+  );
+  assert.equal(promptCalled, false);
+  await agent.close();
+});
+
+test("Flue-style harness rejects invalid Pi skill names", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"unreachable"'),
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  const longName = "a".repeat(65);
+  for (const name of [
+    "",
+    longName,
+    "Bad",
+    "bad name",
+    "bad\n/skill:other",
+    "-bad",
+    "bad-",
+    "bad--name",
+    42,
+  ]) {
+    await assert.rejects(
+      () => session.skill(name),
+      /Invalid Pi skill name/,
+    );
+  }
+  await agent.close();
+});
+
+test("Flue-style harness rejects empty prompt and task text", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"unreachable"'),
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  await assert.rejects(() => session.prompt(" \n\t "), /prompt text must not be empty/);
+  await assert.rejects(() => session.prompt(42), /prompt text must not be empty/);
+  await assert.rejects(() => session.task(""), /prompt text must not be empty/);
+  await assert.rejects(() => session.task(42), /prompt text must not be empty/);
+  await agent.close();
+});
+
+test("Flue-style harness rejects malformed prompt, task, skill, and session options", async () => {
+  let workerCreated = false;
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => {
+      workerCreated = true;
+      return new FakeWorkerSession('"unreachable"');
+    },
+  });
+  const agent = await harness.init();
+
+  await assert.rejects(() => agent.session(" "), /session id must not be empty/);
+  assert.equal(workerCreated, false);
+
+  const session = await agent.session();
+  await assert.rejects(
+    () => session.prompt("Hello", null),
+    /prompt options must be an object/,
+  );
+  await assert.rejects(
+    () => session.prompt("Hello", []),
+    /prompt options must be an object/,
+  );
+  await assert.rejects(
+    () => session.prompt("Hello", { signal: { aborted: false } }),
+    /prompt options signal must be an AbortSignal/,
+  );
+  await assert.rejects(
+    () => session.task("Hello", null),
+    /task options must be an object/,
+  );
+  await assert.rejects(
+    () => session.task("Hello", []),
+    /task options must be an object/,
+  );
+  await assert.rejects(
+    () => session.skill("triage", null),
+    /skill options must be an object/,
+  );
+  await assert.rejects(
+    () => session.skill("triage", []),
+    /skill options must be an object/,
+  );
+  await assert.rejects(
+    () => session.skill("triage", { signal: { aborted: false } }),
+    /skill options signal must be an AbortSignal/,
+  );
+  await agent.close();
+});
+
+test("Flue-style harness accepts parse and safeParse result schemas", async () => {
+  let call = 0;
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => {
+      const session = new FakeWorkerSession('{"answer":"schema"}');
+      const originalPrompt = session.prompt.bind(session);
+      session.prompt = async (text, options) => {
+        const outputs = [
+          '{"answer":"schema"}',
+          '{"answer":"zod"}',
+          '{"answer":"pi"}',
+          '{"answer":"callback"}',
+        ];
+        session.outputText = outputs[call++];
+        await originalPrompt(text, options);
+      };
+      return session;
+    },
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  const parsed = await session.prompt("Parse this.", {
+    result: {
+      parse(value) {
+        return value.answer.toUpperCase();
+      },
+    },
+  });
+  const safeParsed = await session.prompt("Safe parse this.", {
+    result: {
+      safeParse(value) {
+        return { success: true, data: value.answer };
+      },
+    },
+  });
+  const outputParsed = await session.prompt("Safe parse this to output.", {
+    result: {
+      safeParse(value) {
+        return { success: true, output: value.answer };
+      },
+    },
+  });
+  const callbackParsed = await session.prompt("Callback parse this.", {
+    result: (value) => value.answer,
+  });
+  await session.close();
+
+  assert.equal(parsed, "SCHEMA");
+  assert.equal(safeParsed, "zod");
+  assert.equal(outputParsed, "pi");
+  assert.equal(callbackParsed, "callback");
+});
+
+test("Flue-style harness returns raw assistant text by default", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("plain text"),
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  assert.equal(await session.prompt("Return text."), "plain text");
+  await session.close();
+});
+
+test("Flue-style harness reports schema validation failures", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('{"answer":"bad"}'),
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  await assert.rejects(
+    () =>
+      session.prompt("Validate this.", {
+        result: {
+          safeParse() {
+            return { success: false, error: new Error("answer must be number") };
+          },
+        },
+      }),
+    /answer must be number/,
+  );
+  await session.close();
+});
+
+test("Flue-style harness reports invalid JSON result parsing failures", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("not json"),
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  await assert.rejects(
+    () => session.prompt("Return JSON.", { result: "json" }),
+    /CamlFlow effect returned invalid JSON/,
+  );
+  await agent.close();
+});
+
+test("Flue-style harness propagates custom parser failures", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('{"answer":"bad"}'),
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  await assert.rejects(
+    () =>
+      session.prompt("Parse with callback.", {
+        result: () => {
+          throw new Error("callback parser failed");
+        },
+      }),
+    /callback parser failed/,
+  );
+  await agent.close();
+});
+
+test("Flue-style harness rejects invalid result parser shapes", async () => {
+  const cases = [
+    {
+      result: "xml",
+      message: /result parser must be/,
+    },
+    {
+      result: {},
+      message: /result parser must be/,
+    },
+    {
+      result: { parse: true },
+      message: /result parser parse must be a function/,
+    },
+    {
+      result: { safeParse: () => ({ success: true }) },
+      message: /success must include output or data/,
+    },
+    {
+      result: { safeParse: () => ({ success: "yes" }) },
+      message: /safeParse must return a success result/,
+    },
+  ];
+
+  for (const { result, message } of cases) {
+    const harness = createPiCamlFlowHarness({
+      runtime: createRuntime(),
+      workerSessionFactory: async () => new FakeWorkerSession('{"answer":"ok"}'),
+    });
+    const agent = await harness.init();
+    const session = await agent.session();
+
+    await assert.rejects(
+      () => session.prompt("Parse with invalid parser.", { result }),
+      message,
+    );
+    await agent.close();
+  }
+});
+
+test("Flue-style harness rejects malformed result parser options before prompting", async () => {
+  const cases = [
+    { result: null, message: /result parser must be/ },
+    { result: false, message: /result parser must be/ },
+    { result: [], message: /result parser must be/ },
+    { result: {}, message: /result parser must be/ },
+    { result: { parse: true }, message: /result parser parse must be a function/ },
+  ];
+
+  for (const { result, message } of cases) {
+    let promptCalled = false;
+    const harness = createPiCamlFlowHarness({
+      runtime: createRuntime(),
+      workerSessionFactory: async () => {
+        const session = new FakeWorkerSession('{"answer":"ok"}');
+        session.prompt = async () => {
+          promptCalled = true;
+        };
+        return session;
+      },
+    });
+    const agent = await harness.init();
+    const session = await agent.session();
+
+    await assert.rejects(
+      () => session.prompt("Parse with invalid parser.", { result }),
+      message,
+    );
+    assert.equal(promptCalled, false);
+    await agent.close();
+  }
+});
+
+test("Flue-style harness does not reuse stale assistant output", async () => {
+  let promptCount = 0;
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => {
+      const session = new FakeWorkerSession('"first"');
+      const originalPrompt = session.prompt.bind(session);
+      session.prompt = async (text, options) => {
+        promptCount += 1;
+        if (promptCount === 1) {
+          await originalPrompt(text, options);
+        }
+      };
+      return session;
+    },
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  assert.equal(await session.prompt("First prompt.", { result: "json" }), "first");
+  await assert.rejects(
+    () => session.prompt("Second prompt."),
+    /produced no assistant message/,
+  );
+  await session.close();
+});
+
+test("Flue-style harness rejects malformed latest assistant output", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => {
+      const session = new FakeWorkerSession('"first"');
+      const originalPrompt = session.prompt.bind(session);
+      session.prompt = async (text, options) => {
+        await originalPrompt(text, options);
+        session.messages.push({
+          role: "assistant",
+          content: "malformed",
+          stopReason: "stop",
+        });
+      };
+      return session;
+    },
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  await assert.rejects(
+    () => session.prompt("Return text."),
+    /assistant message content must be an array/,
+  );
+  await agent.close();
+});
+
+test("Flue-style harness rejects malformed assistant status fields", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => {
+      const session = new FakeWorkerSession('"unreachable"');
+      session.prompt = async () => {
+        session.messages.push({
+          role: "assistant",
+          content: [{ type: "text", text: '"unreachable"' }],
+          stopReason: "error",
+          errorMessage: { message: "boom" },
+        });
+      };
+      return session;
+    },
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  await assert.rejects(
+    () => session.prompt("Hello."),
+    /assistant message errorMessage must be a string/,
+  );
+  await session.close();
+  await agent.close();
+});
+
+test("Flue-style harness rejects overlapping prompts in one session", async () => {
+  const worker = new FakeWorkerSession('"done"');
+  worker.waitForAbort = true;
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => worker,
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  const pendingPrompt = session.prompt("Slow prompt.");
+  await worker.promptStarted;
+
+  await assert.rejects(
+    () => session.prompt("Overlapping prompt."),
+    /already has an active prompt/,
+  );
+  await session.abort();
+  await assert.rejects(pendingPrompt, /CamlFlow effect cancelled/);
+  await agent.close();
+});
+
+test("Flue-style harness prompt honors external abort signals", async () => {
+  const worker = new FakeWorkerSession('"done"');
+  worker.waitForAbort = true;
+  const controller = new AbortController();
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => worker,
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  const pendingPrompt = session.prompt("Abort this prompt.", {
+    signal: controller.signal,
+  });
+  await worker.promptStarted;
+  controller.abort();
+
+  await assert.rejects(pendingPrompt, /CamlFlow effect cancelled/);
+  assert.equal(worker.abortCalled, true);
+  await agent.close();
+});
+
+test("Flue-style harness prompt removes external abort listeners after completion", async () => {
+  const controller = new AbortController();
+  const abortListeners = countAbortSignalListeners(controller.signal);
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"done"'),
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  assert.equal(
+    await session.prompt("Complete this prompt.", {
+      result: "json",
+      signal: controller.signal,
+    }),
+    "done",
+  );
+  assert.equal(abortListeners.added, 1);
+  assert.equal(abortListeners.removed, 1);
+  await agent.close();
+});
+
+test("Flue-style harness prompt removes external abort listeners after failure", async () => {
+  const controller = new AbortController();
+  const abortListeners = countAbortSignalListeners(controller.signal);
+  const worker = new FakeWorkerSession('"unreachable"');
+  worker.prompt = async () => {
+    throw new Error("prompt failed");
+  };
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => worker,
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  await assert.rejects(
+    () => session.prompt("Fail this prompt.", { signal: controller.signal }),
+    /prompt failed/,
+  );
+  assert.equal(abortListeners.added, 1);
+  assert.equal(abortListeners.removed, 1);
+  await agent.close();
+});
+
+test("Flue-style harness prompt preserves primary failures when listener cleanup fails", async () => {
+  const controller = new AbortController();
+  controller.signal.removeEventListener = () => {
+    throw new Error("remove listener failed");
+  };
+  const worker = new FakeWorkerSession('"unreachable"');
+  worker.prompt = async () => {
+    throw new Error("prompt failed");
+  };
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => worker,
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  await assert.rejects(
+    () => session.prompt("Fail cleanup prompt.", { signal: controller.signal }),
+    /prompt failed/,
+  );
+  await agent.close();
+});
+
+test("Flue-style harness prompt reports listener cleanup failures after success", async () => {
+  const controller = new AbortController();
+  controller.signal.removeEventListener = () => {
+    throw new Error("remove listener failed");
+  };
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"done"'),
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  await assert.rejects(
+    () =>
+      session.prompt("Successful prompt with cleanup failure.", {
+        result: "json",
+        signal: controller.signal,
+      }),
+    /remove listener failed/,
+  );
+  await agent.close();
+});
+
+test("session close waits for an active prompt to settle", async () => {
+  let promptSettled = false;
+  const worker = new FakeWorkerSession('"done"');
+  worker.waitForAbort = true;
+  const originalPrompt = worker.prompt.bind(worker);
+  worker.prompt = async (text, options) => {
+    await originalPrompt(text, options);
+    promptSettled = true;
+  };
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => worker,
+  });
+  const agent = await harness.init();
+  const session = await agent.session();
+
+  const pendingPrompt = session.prompt("Close while this prompt is active.");
+  await worker.promptStarted;
+  await session.close();
+
+  assert.equal(worker.abortCalled, true);
+  assert.equal(promptSettled, true);
+  await assert.rejects(pendingPrompt, /CamlFlow effect cancelled/);
+  await agent.close();
+});
+
+test("Flue-style harness task runs in a detached session sharing the sandbox", async () => {
+  const created = [];
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async (_request, options) => {
+      const session = new FakeWorkerSession(`"${options.cwd}:${created.length}"`);
+      session.cwd = options.cwd;
+      created.push(session);
+      return session;
+    },
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: "/virtual/tasks",
+      tools: [],
+    },
+  });
+  const session = await agent.session("main");
+
+  const result = await session.task("Research independently.", { result: "json" });
+
+  assert.equal(result, "/virtual/tasks:1");
+  assert.equal(created.length, 2);
+  assert.equal(created[0].disposeCalled, false);
+  assert.equal(created[1].disposeCalled, true);
+  assert.equal(session.cwd, "/virtual/tasks");
+  await agent.close();
+  assert.equal(created[0].disposeCalled, true);
+});
+
+test("Flue-style harness task reports child close failures after successful prompts", async () => {
+  const parent = new FakeWorkerSession('"parent"');
+  const child = new FakeWorkerSession('"task"');
+  child.disposeError = new Error("task dispose failed");
+  const workers = [parent, child];
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => workers.shift(),
+  });
+  const agent = await harness.init({ sandbox: "local" });
+  const session = await agent.session("main");
+
+  await assert.rejects(
+    () => session.task("Task with cleanup failure.", { result: "json" }),
+    /task dispose failed/,
+  );
+  assert.equal(child.disposeCalls, 1);
+
+  await agent.close();
+});
+
+test("Flue-style harness task preserves prompt failures when child close fails", async () => {
+  const parent = new FakeWorkerSession('"parent"');
+  const child = new FakeWorkerSession("not json");
+  child.disposeError = new Error("task dispose failed");
+  const workers = [parent, child];
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => workers.shift(),
+  });
+  const agent = await harness.init({ sandbox: "local" });
+  const session = await agent.session("main");
+
+  await assert.rejects(
+    () => session.task("Task with primary failure.", { result: "json" }),
+    /CamlFlow effect returned invalid JSON/,
+  );
+  assert.equal(child.disposeCalls, 1);
+
+  await agent.close();
+});
+
+test("local harness sandbox exposes trusted shell execution with stdin and env", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("ok"),
+  });
+  const agent = await harness.init({ cwd: process.cwd(), sandbox: "local" });
+  const session = await agent.session();
+
+  const result = await session.shell(
+    "node -e \"process.stdin.pipe(process.stdout); console.error(process.env.CAMLFLOW_TEST)\"",
+    {
+      stdin: "hello",
+      env: { CAMLFLOW_TEST: "sandbox" },
+    },
+  );
+  await session.close();
+
+  assert.equal(result.code, 0);
+  assert.equal(result.stdout, "hello");
+  assert.match(result.stderr, /sandbox/);
+});
+
+test("trusted shell rejects empty commands before invoking executors", async () => {
+  let shellCalls = 0;
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("ok"),
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: process.cwd(),
+      tools: [],
+      shell: async () => {
+        shellCalls += 1;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "ran",
+          stderr: "",
+        };
+      },
+    },
+  });
+  const session = await agent.session();
+
+  await assert.rejects(
+    () => session.shell(" \n\t "),
+    /shell command must not be empty/,
+  );
+  await assert.rejects(
+    () => session.shell(42),
+    /shell command must not be empty/,
+  );
+  assert.equal(shellCalls, 0);
+  await agent.close();
+});
+
+test("trusted shell rejects invalid timeouts before invoking executors", async () => {
+  let shellCalls = 0;
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("ok"),
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: process.cwd(),
+      tools: [],
+      shell: async () => {
+        shellCalls += 1;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "ran",
+          stderr: "",
+        };
+      },
+    },
+  });
+  const session = await agent.session();
+
+  for (const timeoutMs of [-1, Number.POSITIVE_INFINITY, Number.NaN, "50"]) {
+    await assert.rejects(
+      () => session.shell("echo no", { timeoutMs }),
+      /timeoutMs must be a finite non-negative number/,
+    );
+  }
+  assert.equal(shellCalls, 0);
+  await agent.close();
+});
+
+test("trusted shell rejects malformed option fields before invoking executors", async () => {
+  let shellCalls = 0;
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("ok"),
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: process.cwd(),
+      tools: [],
+      shell: async () => {
+        shellCalls += 1;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "ran",
+          stderr: "",
+        };
+      },
+    },
+  });
+  const session = await agent.session();
+
+  const hiddenEnv = { GOOD: "value" };
+  Object.defineProperty(hiddenEnv, "HIDDEN", {
+    enumerable: false,
+    value: "secret",
+  });
+  const symbolEnv = { GOOD: "value" };
+  symbolEnv[Symbol("SECRET")] = "secret";
+
+  await assert.rejects(
+    () => session.shell("echo no", null),
+    /shell options must be an object/,
+  );
+  await assert.rejects(
+    () => session.shell("echo no", []),
+    /shell options must be an object/,
+  );
+  await assert.rejects(
+    () => session.shell("echo no", { cwd: " " }),
+    /shell cwd must not be empty/,
+  );
+  await assert.rejects(
+    () => session.shell("echo no", { env: [] }),
+    /shell env must be an object/,
+  );
+  await assert.rejects(
+    () => session.shell("echo no", { env: new Date() }),
+    /shell env must be a plain object/,
+  );
+  await assert.rejects(
+    () => session.shell("echo no", { env: hiddenEnv }),
+    /shell env.HIDDEN must be enumerable/,
+  );
+  await assert.rejects(
+    () => session.shell("echo no", { env: symbolEnv }),
+    /shell env must not contain symbol keys/,
+  );
+  await assert.rejects(
+    () => session.shell("echo no", { env: { BAD: 42 } }),
+    /shell env value for BAD must be a string or undefined/,
+  );
+  await assert.rejects(
+    () => session.shell("echo no", { stdin: 42 }),
+    /shell stdin must be a string/,
+  );
+  await assert.rejects(
+    () => session.shell("echo no", { signal: { aborted: false } }),
+    /shell signal must be an AbortSignal/,
+  );
+  await assert.rejects(
+    () => session.shell("echo \0"),
+    /shell command must not contain NUL bytes/,
+  );
+  await assert.rejects(
+    () => session.shell("echo no", { cwd: "bad\0cwd" }),
+    /shell cwd must not contain NUL bytes/,
+  );
+  await assert.rejects(
+    () => session.shell("echo no", { env: { "BAD=NAME": "value" } }),
+    /shell env names must not contain =/,
+  );
+  await assert.rejects(
+    () => session.shell("echo no", { env: { BAD: "bad\0value" } }),
+    /shell env value for BAD must not contain NUL bytes/,
+  );
+  await assert.rejects(
+    () => session.shell("echo no", { stdin: "bad\0stdin" }),
+    /shell stdin must not contain NUL bytes/,
+  );
+  assert.equal(shellCalls, 0);
+  await agent.close();
+});
+
+test("trusted shell cwd cannot escape the sandbox root", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("ok"),
+  });
+  const agent = await harness.init({ cwd: process.cwd(), sandbox: "local" });
+  const session = await agent.session();
+
+  await assert.rejects(
+    () => session.shell("pwd", { cwd: ".." }),
+    /escapes sandbox root/,
+  );
+  await assert.rejects(
+    () => session.shell("pwd", { cwd: "/tmp" }),
+    /escapes sandbox root/,
+  );
+  await session.close();
+  await agent.close();
+});
+
+test("local trusted shell blocks symlink cwd escapes", async () => {
+  const root = await mkdtemp(join(tmpdir(), "camlflow-shell-root-"));
+  const outside = await mkdtemp(join(tmpdir(), "camlflow-shell-outside-"));
+  try {
+    await symlink(outside, join(root, "escape"), "dir");
+    const harness = createPiCamlFlowHarness({
+      runtime: createRuntime(),
+      workerSessionFactory: async () => new FakeWorkerSession("ok"),
+    });
+    const agent = await harness.init({ cwd: root, sandbox: "local" });
+    const session = await agent.session();
+
+    await assert.rejects(
+      () => session.shell("pwd", { cwd: "escape" }),
+      /escapes sandbox root/,
+    );
+    await agent.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  }
+});
+
+test("local trusted shell reports missing cwd without poisoning the session", async () => {
+  const root = await mkdtemp(join(tmpdir(), "camlflow-shell-missing-"));
+  try {
+    const harness = createPiCamlFlowHarness({
+      runtime: createRuntime(),
+      workerSessionFactory: async () => new FakeWorkerSession("ok"),
+    });
+    const agent = await harness.init({ cwd: root, sandbox: "local" });
+    const session = await agent.session();
+
+    await assert.rejects(
+      () => session.shell("pwd", { cwd: "missing" }),
+      /ENOENT|no such file or directory/,
+    );
+    const result = await session.shell("pwd");
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stdout.trim(), root);
+    await agent.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("trusted shell timeout terminates the command", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("ok"),
+  });
+  const agent = await harness.init({ cwd: process.cwd(), sandbox: "local" });
+  const session = await agent.session();
+
+  const result = await session.shell("node -e \"setTimeout(() => {}, 5000)\"", {
+    timeoutMs: 50,
+  });
+
+  assert.equal(result.signal, "SIGTERM");
+  await agent.close();
+});
+
+test("local trusted shell does not spawn with a pre-aborted signal", async () => {
+  const root = await mkdtemp(join(tmpdir(), "camlflow-shell-preabort-"));
+  try {
+    const controller = new AbortController();
+    controller.abort();
+    const harness = createPiCamlFlowHarness({
+      runtime: createRuntime(),
+      workerSessionFactory: async () => new FakeWorkerSession("ok"),
+    });
+    const agent = await harness.init({ cwd: root, sandbox: "local" });
+    const session = await agent.session();
+
+    const result = await session.shell(
+      "node -e \"require('node:fs').writeFileSync('marker', 'ran')\"",
+      { signal: controller.signal },
+    );
+
+    assert.equal(result.signal, "SIGTERM");
+    assert.equal(existsSync(join(root, "marker")), false);
+    await agent.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("local trusted shell honors external abort signals", async () => {
+  const root = await mkdtemp(join(tmpdir(), "camlflow-shell-abort-"));
+  try {
+    const controller = new AbortController();
+    const harness = createPiCamlFlowHarness({
+      runtime: createRuntime(),
+      workerSessionFactory: async () => new FakeWorkerSession("ok"),
+    });
+    const agent = await harness.init({ cwd: root, sandbox: "local" });
+    const session = await agent.session();
+
+    const pendingShell = session.shell(
+      "node -e \"require('node:fs').writeFileSync('started', 'yes'); setTimeout(() => {}, 5000)\"",
+      { signal: controller.signal },
+    );
+    while (!existsSync(join(root, "started"))) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    controller.abort();
+    const result = await pendingShell;
+
+    assert.equal(readFileSync(join(root, "started"), "utf8"), "yes");
+    assert.equal(result.signal, "SIGTERM");
+    await agent.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("read-only harness sandbox disables host shell execution", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("ok"),
+  });
+  const agent = await harness.init({ sandbox: "read-only" });
+  const session = await agent.session();
+
+  await assert.rejects(
+    async () => session.shell("echo denied"),
+    /does not allow host shell/,
+  );
+  await session.close();
+});
+
+test("harness rejects unknown sandbox kinds before creating a session", async () => {
+  let workerCreated = false;
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => {
+      workerCreated = true;
+      return new FakeWorkerSession("ok");
+    },
+  });
+  const agent = await harness.init({ sandbox: "danger-full-access" });
+
+  await assert.rejects(
+    () => agent.session(),
+    /Unknown Pi CamlFlow sandbox kind: danger-full-access/,
+  );
+  assert.equal(workerCreated, false);
+  await agent.close();
+});
+
+test("harness rejects custom sandboxes without explicit tools", async () => {
+  let workerCreated = false;
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => {
+      workerCreated = true;
+      return new FakeWorkerSession("ok");
+    },
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: "/virtual/custom-without-tools",
+    },
+  });
+
+  await assert.rejects(
+    () => agent.session(),
+    /Custom Pi CamlFlow sandboxes must provide tools/,
+  );
+  assert.equal(workerCreated, false);
+  await agent.close();
+});
+
+test("harness rejects invalid sandbox config fields before creating a session", async () => {
+  const cases = [
+    {
+      sandbox: null,
+      message: /sandbox config must be an object, string, or factory/,
+    },
+    {
+      sandbox: ["local"],
+      message: /sandbox config must be an object, string, or factory/,
+    },
+    {
+      sandbox: { kind: "local", cwd: " " },
+      message: /sandbox cwd must not be empty/,
+    },
+    {
+      sandbox: { kind: "local", cwd: "bad\0cwd" },
+      message: /sandbox cwd must not contain NUL bytes/,
+    },
+    {
+      sandbox: { kind: "custom", cwd: "/virtual", tools: "files" },
+      message: /sandbox tools must be an array or factory/,
+    },
+    {
+      sandbox: { kind: "local", tools: () => "files" },
+      message: /sandbox tools must be an array or factory/,
+    },
+    {
+      sandbox: { kind: "custom", cwd: "/virtual", tools: [], shell: true },
+      message: /sandbox shell must be a function or false/,
+    },
+    {
+      sandbox: { kind: "ephemeral", cleanup: "yes" },
+      message: /sandbox cleanup must be a boolean/,
+    },
+    {
+      sandbox: { kind: "local", cleanup: true },
+      message: /sandbox cleanup is only supported for ephemeral/,
+    },
+    {
+      sandbox: { kind: "ephemeral", dispose: true },
+      message: /sandbox dispose must be a function/,
+    },
+    {
+      sandbox: () => undefined,
+      message: /sandbox factory must return a sandbox config/,
+    },
+    {
+      sandbox: () => 42,
+      message: /sandbox config must be an object, string, or factory/,
+    },
+  ];
+
+  for (const { sandbox, message } of cases) {
+    let workerCreated = false;
+    const harness = createPiCamlFlowHarness({
+      runtime: createRuntime(),
+      workerSessionFactory: async () => {
+        workerCreated = true;
+        return new FakeWorkerSession("ok");
+      },
+    });
+    const agent = await harness.init({ sandbox });
+
+    await assert.rejects(() => agent.session(), message);
+    assert.equal(workerCreated, false);
+    await agent.close();
+  }
+});
+
+test("agent owns and reuses sandbox state across sessions", async () => {
+  const createdSessions = [];
+  let disposeCalls = 0;
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async (_request, options) => {
+      const session = new FakeWorkerSession('"ok"');
+      session.cwd = options.cwd;
+      createdSessions.push(session);
+      return session;
+    },
+  });
+
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: "/virtual/workspace",
+      tools: [],
+      dispose: () => {
+        disposeCalls += 1;
+      },
+    },
+  });
+
+  const first = await agent.session("first");
+  const second = await agent.session("second");
+  assert.equal(first.cwd, "/virtual/workspace");
+  assert.equal(second.cwd, "/virtual/workspace");
+  await first.close();
+
+  assert.equal(disposeCalls, 0);
+  assert.equal(createdSessions[0].disposeCalled, true);
+  assert.equal(createdSessions[1].disposeCalled, false);
+
+  await agent.close();
+  await agent.close();
+
+  assert.equal(createdSessions[1].disposeCalled, true);
+  assert.equal(disposeCalls, 1);
+  await assert.rejects(async () => agent.session("after-close"), /agent is closed/);
+});
+
+test("agent resolves a Flue-style sandbox factory once", async () => {
+  let factoryCalls = 0;
+  let disposeCalls = 0;
+  const workerCwds = [];
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async (_request, options) => {
+      workerCwds.push(options.cwd);
+      return new FakeWorkerSession('"ok"');
+    },
+  });
+  const agent = await harness.init({
+    cwd: "/host/factory",
+    sandbox: (cwd) => {
+      factoryCalls += 1;
+      assert.equal(cwd, "/host/factory");
+      return {
+        kind: "custom",
+        cwd: "/virtual/factory",
+        tools: [],
+        dispose: () => {
+          disposeCalls += 1;
+        },
+      };
+    },
+  });
+
+  const first = await agent.session("first");
+  const second = await agent.session("second");
+  await first.close();
+  await second.close();
+  await agent.close();
+
+  assert.equal(factoryCalls, 1);
+  assert.deepEqual(workerCwds, ["/virtual/factory", "/virtual/factory"]);
+  assert.equal(disposeCalls, 1);
+});
+
+test("agent close still releases the sandbox when a worker dispose fails", async () => {
+  let disposeCalls = 0;
+  const worker = new FakeWorkerSession('"ok"');
+  worker.disposeError = new Error("worker dispose failed");
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => worker,
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: "/virtual/dispose-failure",
+      tools: [],
+      dispose: () => {
+        disposeCalls += 1;
+      },
+    },
+  });
+
+  await agent.session("failure");
+
+  await assert.rejects(() => agent.close(), /worker dispose failed/);
+  assert.equal(disposeCalls, 1);
+  await agent.close();
+  assert.equal(disposeCalls, 1);
+  await assert.rejects(() => agent.session("after-close"), /agent is closed/);
+});
+
+test("closing an agent closes open harness sessions", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"ok"'),
+  });
+  const agent = await harness.init({ cwd: process.cwd(), sandbox: "local" });
+  const session = await agent.session();
+
+  await agent.close();
+
+  await assert.rejects(() => session.prompt("after close"), /session is closed/);
+  await assert.rejects(() => session.shell("echo after close"), /session is closed/);
+});
+
+test("session close still disposes the worker when abort fails", async () => {
+  let sandboxDisposeCalls = 0;
+  const worker = new FakeWorkerSession('"ok"');
+  worker.abortError = new Error("abort failed");
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => worker,
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: "/virtual/abort-failure",
+      tools: [],
+      dispose: () => {
+        sandboxDisposeCalls += 1;
+      },
+    },
+  });
+  const session = await agent.session("abort-failure");
+
+  await assert.rejects(() => session.close(), /abort failed/);
+  assert.equal(worker.abortCalled, true);
+  assert.equal(worker.disposeCalled, true);
+  assert.equal(sandboxDisposeCalls, 0);
+
+  await agent.close();
+  assert.equal(sandboxDisposeCalls, 1);
+});
+
+test("closing an agent during session creation disposes the late worker", async () => {
+  let releaseWorker;
+  let lateWorker;
+  let signalWorkerStarted;
+  const workerGate = new Promise((resolve) => {
+    releaseWorker = resolve;
+  });
+  const workerStarted = new Promise((resolve) => {
+    signalWorkerStarted = resolve;
+  });
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => {
+      signalWorkerStarted();
+      await workerGate;
+      lateWorker = new FakeWorkerSession('"late"');
+      return lateWorker;
+    },
+  });
+  const agent = await harness.init({ sandbox: "local" });
+
+  const pendingSession = agent.session("slow");
+  await workerStarted;
+  await agent.close();
+  releaseWorker();
+
+  await assert.rejects(pendingSession, /agent is closed/);
+  assert.equal(lateWorker.disposeCalled, true);
+});
+
+test("closing an agent during session creation preserves the closed error when late worker dispose fails", async () => {
+  let releaseWorker;
+  let lateWorker;
+  let signalWorkerStarted;
+  const workerGate = new Promise((resolve) => {
+    releaseWorker = resolve;
+  });
+  const workerStarted = new Promise((resolve) => {
+    signalWorkerStarted = resolve;
+  });
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => {
+      signalWorkerStarted();
+      await workerGate;
+      lateWorker = new FakeWorkerSession('"late"');
+      lateWorker.disposeError = new Error("late dispose failed");
+      return lateWorker;
+    },
+  });
+  const agent = await harness.init({ sandbox: "local" });
+
+  const pendingSession = agent.session("slow-dispose");
+  await workerStarted;
+  await agent.close();
+  releaseWorker();
+
+  await assert.rejects(pendingSession, /agent is closed/);
+  assert.equal(lateWorker.disposeCalls, 1);
+});
+
+test("closing an agent during sandbox creation disposes the late sandbox", async () => {
+  let releaseSandbox;
+  let signalSandboxStarted;
+  let disposeCalls = 0;
+  const sandboxGate = new Promise((resolve) => {
+    releaseSandbox = resolve;
+  });
+  const sandboxStarted = new Promise((resolve) => {
+    signalSandboxStarted = resolve;
+  });
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"late"'),
+  });
+  const agent = await harness.init({
+    sandbox: async () => {
+      signalSandboxStarted();
+      await sandboxGate;
+      return {
+        kind: "custom",
+        cwd: "/virtual/late-sandbox",
+        tools: [],
+        dispose: () => {
+          disposeCalls += 1;
+        },
+      };
+    },
+  });
+
+  const pendingSession = agent.session("slow-sandbox");
+  await sandboxStarted;
+  const pendingClose = agent.close();
+  releaseSandbox();
+
+  await pendingClose;
+  await assert.rejects(pendingSession, /agent is closed/);
+  assert.equal(disposeCalls, 1);
+});
+
+test("closing an agent during workflow sandbox creation rejects the late run", async () => {
+  let releaseSandbox;
+  let signalSandboxStarted;
+  let disposeCalls = 0;
+  let clientCreated = false;
+  const sandboxGate = new Promise((resolve) => {
+    releaseSandbox = resolve;
+  });
+  const sandboxStarted = new Promise((resolve) => {
+    signalSandboxStarted = resolve;
+  });
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"late"'),
+    clientFactory: (options) => {
+      clientCreated = true;
+      return new FakeCamlFlowClient(options);
+    },
+  });
+  const agent = await harness.init({
+    sandbox: async () => {
+      signalSandboxStarted();
+      await sandboxGate;
+      return {
+        kind: "custom",
+        cwd: "/virtual/late-workflow-sandbox",
+        tools: [],
+        dispose: () => {
+          disposeCalls += 1;
+        },
+      };
+    },
+  });
+
+  const pendingRun = agent.runWorkflow({
+    workflowPath: "examples/basic/main.cml",
+  });
+  await sandboxStarted;
+  const pendingClose = agent.close();
+  releaseSandbox();
+
+  await pendingClose;
+  await assert.rejects(pendingRun, /agent is closed/);
+  assert.equal(disposeCalls, 1);
+  assert.equal(clientCreated, false);
+});
+
+test("ephemeral harness sandbox is removed when the agent closes", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"ok"'),
+  });
+  const agent = await harness.init({ sandbox: "ephemeral" });
+  const session = await agent.session();
+  const sandboxCwd = session.cwd;
+
+  assert.equal(existsSync(sandboxCwd), true);
+  await session.close();
+  assert.equal(existsSync(sandboxCwd), true);
+
+  await agent.close();
+  assert.equal(existsSync(sandboxCwd), false);
+});
+
+test("non-ephemeral cleanup flag is rejected before touching host-owned cwd", async () => {
+  const root = await mkdtemp(join(tmpdir(), "camlflow-local-cleanup-"));
+  try {
+    let workerCreated = false;
+    const harness = createPiCamlFlowHarness({
+      runtime: createRuntime(),
+      workerSessionFactory: async () => {
+        workerCreated = true;
+        return new FakeWorkerSession('"ok"');
+      },
+    });
+    const agent = await harness.init({
+      sandbox: {
+        kind: "local",
+        cwd: root,
+        cleanup: true,
+      },
+    });
+
+    await assert.rejects(
+      () => agent.session(),
+      /sandbox cleanup is only supported for ephemeral/,
+    );
+    assert.equal(workerCreated, false);
+    await agent.close();
+
+    assert.equal(existsSync(root), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("ephemeral sandbox cleanup runs even when dispose hook fails", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"ok"'),
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "ephemeral",
+      dispose: () => {
+        throw new Error("dispose hook failed");
+      },
+    },
+  });
+  const session = await agent.session();
+  const sandboxCwd = session.cwd;
+
+  await assert.rejects(() => agent.close(), /dispose hook failed/);
+  assert.equal(existsSync(sandboxCwd), false);
+});
+
+test("ephemeral sandbox cleanup runs when tool creation fails", async () => {
+  let sandboxCwd;
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"unreachable"'),
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "ephemeral",
+      tools: (cwd) => {
+        sandboxCwd = cwd;
+        assert.equal(existsSync(cwd), true);
+        throw new Error("tool setup failed");
+      },
+    },
+  });
+
+  await assert.rejects(() => agent.session(), /tool setup failed/);
+  assert.equal(typeof sandboxCwd, "string");
+  assert.equal(existsSync(sandboxCwd), false);
+  await agent.close();
+});
+
+test("harness workflow runs reuse the agent-owned sandbox for effects", async () => {
+  const workerCwds = [];
+  let disposeCalls = 0;
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async (_request, options) => {
+      workerCwds.push(options.cwd);
+      return new FakeWorkerSession('{"answer":"from workflow"}');
+    },
+    clientFactory: (options) => new FakeCamlFlowClient(options),
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: "/virtual/workflow",
+      tools: [],
+      dispose: () => {
+        disposeCalls += 1;
+      },
+    },
+  });
+
+  const result = await agent.runWorkflow({
+    workflowPath: "examples/basic/main.cml",
+    input: "Ada",
+  });
+
+  assert.deepEqual(result.output, { answer: "from workflow" });
+  assert.deepEqual(workerCwds, ["/virtual/workflow"]);
+  assert.equal(disposeCalls, 0);
+  await agent.close();
+  assert.equal(disposeCalls, 1);
+});
+
+test("closing an agent cancels an active harness workflow run", async () => {
+  let fakeClient;
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession("{}"),
+    clientFactory: (options) => {
+      fakeClient = new HangingCamlFlowClient(options);
+      return fakeClient;
+    },
+  });
+  const agent = await harness.init({ sandbox: "local" });
+
+  const pending = agent.runWorkflow({
+    workflowPath: "examples/basic/main.cml",
+  });
+  while (!fakeClient) {
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  await fakeClient.runStarted;
+  await agent.close();
+
+  await assert.rejects(pending, /cancelled/);
+  assert.equal(fakeClient.runSignal.aborted, true);
+  assert.equal(fakeClient.shutdownCalled, true);
+});
+
+test("session abort cancels an active trusted shell command", async () => {
+  let shellSignal;
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"ok"'),
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: process.cwd(),
+      tools: [],
+      shell: (_command, options = {}) =>
+        new Promise((_resolve, reject) => {
+          shellSignal = options.signal;
+          options.signal.addEventListener(
+            "abort",
+            () => reject(new Error("shell aborted")),
+            { once: true },
+          );
+        }),
+    },
+  });
+  const session = await agent.session();
+
+  const pendingShell = session.shell("sleep 60");
+  while (!shellSignal) {
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  await session.abort();
+
+  assert.equal(shellSignal.aborted, true);
+  await assert.rejects(pendingShell, /shell aborted/);
+  await agent.close();
+});
+
+test("pre-aborted trusted shell call does not invoke custom shell executor", async () => {
+  let shellCalls = 0;
+  const controller = new AbortController();
+  controller.abort();
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"ok"'),
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: process.cwd(),
+      tools: [],
+      shell: async () => {
+        shellCalls += 1;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "ran",
+          stderr: "",
+        };
+      },
+    },
+  });
+  const session = await agent.session();
+
+  const result = await session.shell("should not run", {
+    signal: controller.signal,
+  });
+
+  assert.deepEqual(result, {
+    code: null,
+    signal: "SIGTERM",
+    stdout: "",
+    stderr: "",
+  });
+  assert.equal(shellCalls, 0);
+  await agent.close();
+});
+
+test("trusted shell removes external abort listeners after completion", async () => {
+  const controller = new AbortController();
+  const abortListeners = countAbortSignalListeners(controller.signal);
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"ok"'),
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: process.cwd(),
+      tools: [],
+      shell: async () => ({
+        code: 0,
+        signal: null,
+        stdout: "done",
+        stderr: "",
+      }),
+    },
+  });
+  const session = await agent.session();
+
+  assert.deepEqual(await session.shell("echo done", { signal: controller.signal }), {
+    code: 0,
+    signal: null,
+    stdout: "done",
+    stderr: "",
+  });
+  assert.equal(abortListeners.added, 1);
+  assert.equal(abortListeners.removed, 1);
+  await agent.close();
+});
+
+test("trusted shell removes external abort listeners after sync failure", async () => {
+  const controller = new AbortController();
+  const abortListeners = countAbortSignalListeners(controller.signal);
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"ok"'),
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: process.cwd(),
+      tools: [],
+      shell: () => {
+        throw new Error("sync shell failed");
+      },
+    },
+  });
+  const session = await agent.session();
+
+  await assert.rejects(
+    () => session.shell("throw sync", { signal: controller.signal }),
+    /sync shell failed/,
+  );
+  assert.equal(abortListeners.added, 1);
+  assert.equal(abortListeners.removed, 1);
+  await agent.close();
+});
+
+test("trusted shell preserves primary failures when listener cleanup fails", async () => {
+  const controller = new AbortController();
+  controller.signal.removeEventListener = () => {
+    throw new Error("remove listener failed");
+  };
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"ok"'),
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: process.cwd(),
+      tools: [],
+      shell: () => {
+        throw new Error("shell failed");
+      },
+    },
+  });
+  const session = await agent.session();
+
+  await assert.rejects(
+    () => session.shell("throw sync", { signal: controller.signal }),
+    /shell failed/,
+  );
+  await agent.close();
+});
+
+test("trusted shell reports listener cleanup failures after success", async () => {
+  const controller = new AbortController();
+  controller.signal.removeEventListener = () => {
+    throw new Error("remove listener failed");
+  };
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"ok"'),
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: process.cwd(),
+      tools: [],
+      shell: async () => ({
+        code: 0,
+        signal: null,
+        stdout: "done",
+        stderr: "",
+      }),
+    },
+  });
+  const session = await agent.session();
+
+  await assert.rejects(
+    () => session.shell("echo done", { signal: controller.signal }),
+    /remove listener failed/,
+  );
+  await agent.close();
+});
+
+test("trusted shell accepts synchronous executor results", async () => {
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"ok"'),
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: process.cwd(),
+      tools: [],
+      shell: () => ({
+        code: 0,
+        signal: null,
+        stdout: "sync",
+        stderr: "",
+      }),
+    },
+  });
+  const session = await agent.session();
+
+  assert.deepEqual(await session.shell("sync result"), {
+    code: 0,
+    signal: null,
+    stdout: "sync",
+    stderr: "",
+  });
+  await agent.close();
+});
+
+test("trusted shell rejects malformed custom executor results", async () => {
+  for (const result of [
+    {
+      code: 0,
+      signal: null,
+      stdout: 42,
+      stderr: "",
+    },
+    {
+      code: Number.NaN,
+      signal: null,
+      stdout: "",
+      stderr: "",
+    },
+    {
+      code: -1,
+      signal: null,
+      stdout: "",
+      stderr: "",
+    },
+    {
+      code: 0,
+      signal: "",
+      stdout: "",
+      stderr: "",
+    },
+    {
+      code: 0,
+      signal: "SIG\0TERM",
+      stdout: "",
+      stderr: "",
+    },
+  ]) {
+    const harness = createPiCamlFlowHarness({
+      runtime: createRuntime(),
+      workerSessionFactory: async () => new FakeWorkerSession('"ok"'),
+    });
+    const agent = await harness.init({
+      sandbox: {
+        kind: "custom",
+        cwd: process.cwd(),
+        tools: [],
+        shell: () => result,
+      },
+    });
+    const session = await agent.session();
+
+    await assert.rejects(
+      () => session.shell("bad result"),
+      /invalid shell result|shell result signal/,
+    );
+    await agent.close();
+  }
+});
+
+test("session close waits for active trusted shell settlement", async () => {
+  let shellSignal;
+  let settleShell;
+  let settled = false;
+  const shellSettled = new Promise((resolve) => {
+    settleShell = () => {
+      settled = true;
+      resolve({
+        code: null,
+        signal: "SIGTERM",
+        stdout: "",
+        stderr: "",
+      });
+    };
+  });
+  const harness = createPiCamlFlowHarness({
+    runtime: createRuntime(),
+    workerSessionFactory: async () => new FakeWorkerSession('"ok"'),
+  });
+  const agent = await harness.init({
+    sandbox: {
+      kind: "custom",
+      cwd: process.cwd(),
+      tools: [],
+      shell: (_command, options = {}) => {
+        shellSignal = options.signal;
+        options.signal.addEventListener("abort", () => {
+          setTimeout(settleShell, 10);
+        });
+        return shellSettled;
+      },
+    },
+  });
+  const session = await agent.session();
+
+  const pendingShell = session.shell("sleep 60");
+  while (!shellSignal) {
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  await session.close();
+
+  assert.equal(shellSignal.aborted, true);
+  assert.equal(settled, true);
+  assert.deepEqual(await pendingShell, {
+    code: null,
+    signal: "SIGTERM",
+    stdout: "",
+    stderr: "",
+  });
+});
+
+test("package exports the public Pi harness surface and no slash-command parser", () => {
+  for (const name of [
+    "PiCamlFlowEffectCancelledError",
+    "PiCamlFlowEffectExecutor",
+    "PiCamlFlowMissingModelError",
+    "buildPiCamlFlowEffectPrompt",
+    "createPiCamlFlowHarness",
+    "createPiCamlFlowHostSession",
+    "parseCamlFlowJsonOutput",
+  ]) {
+    assert.equal(typeof sdk[name], "function", `${name} should be exported`);
+  }
   assert.equal("parseCamlFlowCommand" in sdk, false);
   assert.equal("parseCamlFlowRunCommand" in sdk, false);
   assert.equal(
@@ -273,56 +4248,124 @@ test("package exports no slash-command parser", () => {
   );
 });
 
+function createCamlFlowCapabilities(overrides = {}) {
+  return {
+    check: true,
+    compile: true,
+    run: true,
+    executeEffect: true,
+    trace: true,
+    diagnostic: true,
+    progress: true,
+    streaming: true,
+    cancelRequest: true,
+    renderedPrompt: true,
+    outputSchema: true,
+    ...overrides,
+  };
+}
+
+function createJsonRpcNotification(method, params) {
+  return {
+    jsonrpc: "2.0",
+    method,
+    params,
+  };
+}
+
+function createTraceNotification(overrides = {}) {
+  return {
+    event: "run-start",
+    runId: "run-1",
+    step: null,
+    effect: null,
+    ...overrides,
+  };
+}
+
+function createDiagnosticNotification(overrides = {}) {
+  return {
+    severity: "error",
+    message: "boom",
+    method: "camlflow/run",
+    runId: "run-1",
+    step: null,
+    effect: null,
+    ...overrides,
+  };
+}
+
+function createProgressNotification(overrides = {}) {
+  return {
+    runId: "run-1",
+    stage: "run-start",
+    step: null,
+    message: null,
+    completedSteps: 0,
+    knownSteps: null,
+    cancellable: true,
+    ...overrides,
+  };
+}
+
+function createOutputChunkNotification(overrides = {}) {
+  return {
+    runId: "run-1",
+    step: 1,
+    streamId: "pi:1:bound-agent:greeter",
+    format: "text/plain",
+    delta: "hello",
+    done: false,
+    declaredReturnType: "record",
+    outputSchema: { type: "object" },
+    ...overrides,
+  };
+}
+
 class FakeCamlFlowClient {
   constructor(options) {
     this.options = options;
     this.shutdownCalled = false;
+    this.shutdownCalls = 0;
+    this.initializeCalled = false;
+    this.runCalled = false;
   }
 
   async initialize() {
+    this.initializeCalled = true;
     return {
       protocolVersion: "0.1.0",
       irVersion: "0.1.0",
-      capabilities: {},
+      capabilities: createCamlFlowCapabilities(),
       effectKinds: [],
     };
   }
 
   async run(params, options) {
+    this.runCalled = true;
     this.runParams = params;
     this.runOptions = options;
     const effectResult = await this.options.effectHandler(
+      createExecuteEffectParams(),
       {
-        runId: "run-1",
-        step: 1,
-        effect: {
-          kind: "bound-agent",
-          role: "agent",
-          name: "greeter",
-          input: { name: "Ada" },
-          declaredReturnType: "record",
-          outputSchema: { type: "object" },
-          workingDirectory: null,
-          skillsDirectory: null,
-          skillMarkdown: null,
-          inlineDefinition: null,
-          renderedPrompt: "Say hello to Ada.",
-          requestedModel: null,
-          unsupportedSettings: [],
-          step: 1,
-          runId: "run-1",
-        },
+        jsonrpc: "2.0",
+        id: 1,
+        method: "camlflow/executeEffect",
+        params: createExecuteEffectParams(),
       },
-      { jsonrpc: "2.0", id: 1, method: "camlflow/executeEffect" },
       {
         emitOutputChunk: async (chunk) => {
-          await this.options.onOutputChunk?.({
+          const notificationChunk = {
             runId: "run-1",
             step: 1,
             declaredReturnType: "record",
             outputSchema: { type: "object" },
             ...chunk,
-          });
+          };
+          await this.options.onOutputChunk?.(
+            notificationChunk,
+            createJsonRpcNotification("camlflow/outputChunk", notificationChunk),
+          );
         },
       },
     );
@@ -336,6 +4379,12 @@ class FakeCamlFlowClient {
 
   async shutdownAndExit() {
     this.shutdownCalled = true;
+    this.shutdownCalls += 1;
+    if (this.shutdownError) {
+      const error = this.shutdownError;
+      this.shutdownError = undefined;
+      throw error;
+    }
   }
 }
 

--- a/packages/camlflow-ts-json-rpc-sdk/README.md
+++ b/packages/camlflow-ts-json-rpc-sdk/README.md
@@ -150,7 +150,8 @@ They now cover:
 This harness is historical/manual validation coverage for the original
 `/camlflow-run` prototype. New Pi integrations should use
 [`../camlflow-pi-sdk`](../camlflow-pi-sdk), which wraps this JSON-RPC SDK behind
-a typed programmatic API and leaves command/UI registration to `pi-mono`.
+a typed programmatic API, adds a Flue-style sandbox harness around Pi sessions,
+and leaves command/UI registration to `pi-mono`.
 
 The package now also includes a small Node-based harness for automating the
 `pi-mono` host checks described in the repository docs.


### PR DESCRIPTION
## Summary
- add a Flue-style Pi harness API around CamlFlow workflows
- add sandbox presets, custom sandbox factories, trusted shell support, and agent/session lifecycle handling
- harden runtime, JSON, JSON-RPC, shell, model, assistant-message, parser, and package export boundaries
- add compile-checked harness example and update package/root docs

## Validation
- opam install . --deps-only --with-test --yes --switch 5.4.0
- opam exec --switch 5.4.0 -- dune fmt
- opam exec --switch 5.4.0 -- dune test
- timeout 180s opam exec --switch 5.4.0 -- dune build
- CLI help, basic run with "Ada", and serve --stdio smoke
- packages/camlflow-ts-json-rpc-sdk: npm install && opam exec --switch 5.4.0 -- npm test
- packages/camlflow-pi-sdk: npm install && opam exec --switch 5.4.0 -- npm test
- packages/camlflow-pi-sdk: npm pack --dry-run
- git diff --check
- npm audit --omit=dev --json
