### PR TITLE
feat: add CamlFlow authoring and run docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,33 @@ For a complete install and usage walkthrough, including opam switch setup,
 optional local CLI installation, SDK packages, editor setup, and
 troubleshooting, see
 [`docs/how-to-run-and-install.md`](./docs/how-to-run-and-install.md).
+For a map of all current and historical docs, see
+[`docs/README.md`](./docs/README.md).
+For the authoring path from `.cml` syntax to CLI, provider, JSON-RPC, and Pi
+harness execution, see
+[`docs/writing-and-running-camlflow.md`](./docs/writing-and-running-camlflow.md).
+For a step-by-step first workflow tutorial, see
+[`docs/first-workflow.md`](./docs/first-workflow.md).
+For supported `.cml` declarations, types, expressions, and effects, see
+[`docs/language-reference.md`](./docs/language-reference.md).
+For copyable workflow patterns, see
+[`docs/workflow-cookbook.md`](./docs/workflow-cookbook.md).
+For choosing between deterministic CLI, provider CLI, JSON-RPC, and Pi harness
+runs, see [`docs/run-modes.md`](./docs/run-modes.md).
+For shared terminology across the language, runtime, and host integrations, see
+[`docs/glossary.md`](./docs/glossary.md).
+For exact command shapes and flag precedence, see
+[`docs/cli-reference.md`](./docs/cli-reference.md).
+For `camlflow.json` fields and path resolution, see
+[`docs/project-config.md`](./docs/project-config.md).
+For JSON input and output encoding rules, see
+[`docs/json-encoding.md`](./docs/json-encoding.md).
+For VS Code and Zed language-server setup, see
+[`docs/editor-support.md`](./docs/editor-support.md).
+For Pi host integration and the Flue-style harness, see
+[`docs/pi-sdk-harness.md`](./docs/pi-sdk-harness.md).
+For common failures and fixes, see
+[`docs/troubleshooting.md`](./docs/troubleshooting.md).
 
 Prerequisites:
 
@@ -127,6 +154,9 @@ Try project-local defaults from `camlflow.json`:
 
 Run all commands through `opam exec -- dune exec camlflow -- ...` inside the
 repo.
+For exact flag examples, provider options, project defaults, JSON-RPC bridge
+startup, and common CLI troubleshooting, see
+[`docs/cli-reference.md`](./docs/cli-reference.md).
 
 Available commands:
 
@@ -143,6 +173,9 @@ current directory or a parent contains a `camlflow.json` with a `program`
 field. The nearest config wins.
 
 ## Examples Worth Running
+
+The full examples learning path is in
+[`examples/README.md`](./examples/README.md).
 
 - [`examples/basic`](./examples/basic): smallest bound-agent example
 - [`examples/recursion`](./examples/recursion): pure typed computation
@@ -310,6 +343,8 @@ prototype path.
 If you want a host-side client instead of hand-rolling the protocol, start
 with
 [`packages/camlflow-ts-json-rpc-sdk`](./packages/camlflow-ts-json-rpc-sdk).
+For the maintained Pi harness path, see
+[`docs/pi-sdk-harness.md`](./docs/pi-sdk-harness.md).
 
 ## Editor Support
 
@@ -352,9 +387,20 @@ The editor packages both expect a `camlflow` executable on `PATH` and launch
 
 ## Related Docs
 
+- [`docs/README.md`](./docs/README.md)
 - [`docs/json-rpc.md`](./docs/json-rpc.md)
 - [`docs/provider-execution.md`](./docs/provider-execution.md)
 - [`docs/provider-hooks.md`](./docs/provider-hooks.md)
 - [`docs/json-rpc-status.md`](./docs/json-rpc-status.md)
 - [`docs/how-to-run-and-install.md`](./docs/how-to-run-and-install.md)
+- [`docs/cli-reference.md`](./docs/cli-reference.md)
+- [`docs/language-reference.md`](./docs/language-reference.md)
+- [`docs/glossary.md`](./docs/glossary.md)
+- [`docs/run-modes.md`](./docs/run-modes.md)
+- [`docs/writing-and-running-camlflow.md`](./docs/writing-and-running-camlflow.md)
+- [`docs/workflow-cookbook.md`](./docs/workflow-cookbook.md)
+- [`docs/project-config.md`](./docs/project-config.md)
+- [`docs/json-encoding.md`](./docs/json-encoding.md)
+- [`docs/pi-sdk-harness.md`](./docs/pi-sdk-harness.md)
+- [`docs/troubleshooting.md`](./docs/troubleshooting.md)
 - [`packages/camlflow-ts-json-rpc-sdk/README.md`](./packages/camlflow-ts-json-rpc-sdk/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,117 @@
+# CamlFlow Documentation
+
+This directory contains both current user-facing guides and historical planning
+notes. Start with the current guides unless you are working on protocol or
+implementation internals.
+
+## Start Here
+
+- [`how-to-run-and-install.md`](./how-to-run-and-install.md): install from this
+  checkout, run the CLI, start JSON-RPC mode, run package tests, and set up
+  editors.
+- [`writing-and-running-camlflow.md`](./writing-and-running-camlflow.md): write
+  `.cml` workflows, use `let*`, agents, skills, modules, project defaults,
+  provider runs, JSON-RPC hosts, and the Pi harness.
+- [`first-workflow.md`](./first-workflow.md): step-by-step tutorial from one
+  `.cml` file to structured input, effects, project config, providers,
+  JSON-RPC, and Pi harness usage.
+- [`language-reference.md`](./language-reference.md): compact syntax and
+  declaration reference for the supported `.cml` language surface.
+- [`examples/README.md`](../examples/README.md): guided path through runnable
+  examples.
+- [`workflow-cookbook.md`](./workflow-cookbook.md): copyable patterns for common
+  `.cml` workflow shapes.
+- [`run-modes.md`](./run-modes.md): choose between deterministic CLI, provider
+  CLI, JSON-RPC host, and Pi SDK harness execution.
+- [`glossary.md`](./glossary.md): shared vocabulary for workflows, effects,
+  hosts, providers, JSON-RPC, Pi harness sessions, and sandboxes.
+- [`editor-support.md`](./editor-support.md): VS Code and Zed setup, LSP
+  configuration, schema validation, and editor smoke checks.
+- [`troubleshooting.md`](./troubleshooting.md): common failures and fixes.
+
+## Author References
+
+- [`cli-reference.md`](./cli-reference.md): command shapes, flags, project
+  defaults, provider options, completions, and CLI troubleshooting.
+- [`language-reference.md`](./language-reference.md): supported declarations,
+  types, expressions, effects, operators, and known language limits.
+- [`project-config.md`](./project-config.md): `camlflow.json` fields,
+  precedence, path resolution, and provider defaults.
+- [`json-encoding.md`](./json-encoding.md): CamlFlow type-to-JSON mappings for
+  inputs and provider/host/Pi outputs.
+- [`run-modes.md`](./run-modes.md): execution-mode comparison and bring-up
+  order for workflows.
+- [`glossary.md`](./glossary.md): terminology used across authoring, runtime,
+  host, provider, and Pi harness docs.
+- [`provider-execution.md`](./provider-execution.md): direct CLI provider
+  behavior, preflight, sandbox flags, model selection, and provider tracing.
+- [`provider-hooks.md`](./provider-hooks.md): OCaml runtime hooks for host-owned
+  effect execution.
+
+## Host And SDK Integration
+
+- [`json-rpc.md`](./json-rpc.md): current JSON-RPC protocol reference.
+- [`json-rpc-fixtures.md`](./json-rpc-fixtures.md): concrete wire examples.
+- [`pi-sdk-harness.md`](./pi-sdk-harness.md): maintained Pi SDK host-session and
+  Flue-style harness guide.
+- [`host-adapter-architecture.md`](./host-adapter-architecture.md): host adapter
+  architecture notes.
+- [`../packages/camlflow-ts-json-rpc-sdk/README.md`](../packages/camlflow-ts-json-rpc-sdk/README.md):
+  TypeScript JSON-RPC SDK.
+- [`../packages/camlflow-pi-sdk/README.md`](../packages/camlflow-pi-sdk/README.md):
+  Pi adapter and sandbox-aware harness.
+- [`editor-support.md`](./editor-support.md): editor package setup and LSP
+  troubleshooting for local development.
+
+## Status And Roadmaps
+
+These documents are useful for understanding how the current shape emerged, but
+they are not the shortest path for new users.
+
+- [`json-rpc-status.md`](./json-rpc-status.md): status snapshot for the JSON-RPC
+  track.
+- [`json-rpc-roadmap.md`](./json-rpc-roadmap.md): JSON-RPC roadmap and design
+  context.
+- [`json-rpc-deferred-extensions.md`](./json-rpc-deferred-extensions.md):
+  deferred protocol extension notes.
+- [`json-rpc-checklist.md`](./json-rpc-checklist.md): concise JSON-RPC task
+  checklist.
+- [`mvp-spec-camlflow.md`](./mvp-spec-camlflow.md): MVP product/technical spec.
+- [`alpha-tasks.md`](./alpha-tasks.md), [`beta-1-tasks.md`](./beta-1-tasks.md),
+  and [`beta-2-tasks.md`](./beta-2-tasks.md): milestone task notes.
+
+## Pi Historical Notes
+
+The current maintained Pi integration path is
+[`pi-sdk-harness.md`](./pi-sdk-harness.md) plus
+[`../packages/camlflow-pi-sdk`](../packages/camlflow-pi-sdk).
+
+These older documents describe the original `pi-mono` `/camlflow-run`
+prototype, manual launchers, and fork-local implementation plan:
+
+- [`pi-mono-host-integration-plan.md`](./pi-mono-host-integration-plan.md)
+- [`pi-mono-implementation-checklist.md`](./pi-mono-implementation-checklist.md)
+- [`pi-mono-integration-testing.md`](./pi-mono-integration-testing.md)
+- [`pi-mono-manual-tests.md`](./pi-mono-manual-tests.md)
+
+## Maintainer Context
+
+- [`agent-context/architecture.md`](./agent-context/architecture.md)
+- [`agent-context/api-conventions.md`](./agent-context/api-conventions.md)
+- [`agent-context/testing-guide.md`](./agent-context/testing-guide.md)
+- [`adr/0001-programmatic-camlflow-pi-sdk.md`](./adr/0001-programmatic-camlflow-pi-sdk.md)
+- [`docs-validation.md`](./docs-validation.md)
+
+## Documentation Maintenance
+
+When behavior changes:
+
+- validate runnable snippets with [`docs-validation.md`](./docs-validation.md)
+- update the author guide and CLI reference for user-visible command or flag
+  changes
+- update `json-encoding.md` when type/JSON encoding changes
+- update `json-rpc.md`, fixtures, and SDK READMEs when protocol shapes change
+- update `pi-sdk-harness.md` and the Pi SDK README when harness lifecycle,
+  sandbox, shell, or runtime contracts change
+- keep historical status docs as snapshots unless the project state they
+  describe has changed

--- a/docs/agent-context/testing-guide.md
+++ b/docs/agent-context/testing-guide.md
@@ -7,6 +7,7 @@
 - Run `opam exec -- dune build` when CLI entrypoints, install surfaces, or dune wiring changes.
 - Run `cd packages/camlflow-ts-json-rpc-sdk && npm install && opam exec -- npm test` for RPC, schema, SDK, or host-example changes.
 - Run `cd packages/camlflow-vscode && npm run smoke:highlight` for syntax, schema, or editor package changes.
+- Run the focused checklist in `docs/docs-validation.md` for user-facing docs, examples, SDK READMEs, and editor README changes.
 
 ## Test-Shape Guidance
 - `test/test_camlflow.ml` is intentionally central; extend nearby sections instead of spinning out a second harness by default.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,202 @@
+# CamlFlow CLI Reference
+
+This is the short command reference for running CamlFlow from a repository
+checkout. For setup, see [`how-to-run-and-install.md`](./how-to-run-and-install.md).
+For authoring `.cml` workflows, see
+[`writing-and-running-camlflow.md`](./writing-and-running-camlflow.md).
+For common failures and fixes, see
+[`troubleshooting.md`](./troubleshooting.md).
+
+Run commands from the repository root through Dune:
+
+```sh
+opam exec -- dune exec camlflow -- <command>
+```
+
+If your active shell is not using an OCaml 5.4 switch, use:
+
+```sh
+opam exec --switch 5.4.0 -- dune exec camlflow -- <command>
+```
+
+If bare `dune exec ...` reports that `(lang dune 3.22)` is not supported, your
+shell is using an older Dune binary. Use `opam exec --switch 5.4.0 -- dune ...`
+or activate that switch first.
+
+## Commands
+
+| Command | Use |
+| --- | --- |
+| `parse <file.cml>` | Parse one source file and report declaration count. |
+| `check [file.cml] [-I dir]...` | Load, resolve modules, and type-check a workflow. |
+| `compile [file.cml] [-I dir]... [-o artifact.json]` | Emit compiled JSON IR. |
+| `run [file.cml\|artifact.json] ...` | Execute source or compiled IR. |
+| `serve --stdio` | Start the JSON-RPC bridge. |
+| `lsp` | Start the language server. |
+| `completion <bash\|zsh\|fish>` | Emit shell completions. |
+
+`check`, `compile`, and `run` may omit the file argument when the nearest
+`camlflow.json` supplies `program`.
+For the full config field reference, see
+[`project-config.md`](./project-config.md).
+
+## Authoring Loop
+
+```sh
+opam exec -- dune exec camlflow -- parse examples/basic/main.cml
+opam exec -- dune exec camlflow -- check examples/basic/main.cml
+opam exec -- dune exec camlflow -- compile examples/basic/main.cml -o /tmp/basic.ir.json
+opam exec -- dune exec camlflow -- run /tmp/basic.ir.json --input-json '"Ada"'
+```
+
+Use source runs while editing. Use compiled IR when a host wants to inspect,
+cache, or pass around the checked workflow shape.
+
+## Run Inputs
+
+Use `--input-json` for small inline JSON values:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/basic/main.cml --input-json '"Ada"'
+opam exec -- dune exec camlflow -- run examples/recursion/main.cml --input-json '4'
+```
+
+Use `--input` for structured payloads:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/problem-coach/main.cml \
+  --skills examples/problem-coach/skills \
+  --input examples/problem-coach/input.json
+```
+
+If `--input` and `--input-json` are both omitted, the entrypoint must take no
+argument.
+
+## Include Paths And Skills
+
+Add module search paths with repeated `-I` flags:
+
+```sh
+opam exec -- dune exec camlflow -- check examples/qualified-imports/main.cml \
+  -I examples/qualified-imports
+```
+
+Use local prompt-backed skills with `--skills`:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/local-skill/main.cml \
+  --skills examples/local-skill/skills \
+  --input-json '"hello"'
+```
+
+The skill layout is:
+
+```text
+skills/
+  skill-name/
+    SKILL.md
+```
+
+## Project Defaults
+
+`camlflow.json` can provide defaults for program, entrypoint, include paths,
+skills, and provider options:
+
+```json
+{
+  "program": "main.cml",
+  "entry": "main",
+  "includePaths": ["."],
+  "skillsDir": "skills"
+}
+```
+
+From that project directory:
+
+```sh
+opam exec -- dune exec camlflow -- check
+opam exec -- dune exec camlflow -- run --input input.json
+```
+
+Precedence is:
+
+1. explicit CLI flags
+2. nearest `camlflow.json`
+3. built-in defaults
+
+Relative `program`, `includePaths`, `skillsDir`, and `allowWriteDirs` entries
+resolve from the config file directory.
+
+## Provider Runs
+
+Provider-backed runs delegate each effectful `let*` step to an external tool:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/codex/main.cml \
+  --skills examples/codex/skills \
+  --input-json '"Ada"' \
+  --provider codex \
+  --model gpt-5.4-mini \
+  --reasoning low \
+  --sandbox read-only \
+  --trace-provider
+```
+
+Supported provider names:
+
+- `codex`
+- `opencode`
+- `claude-code`
+- `claude-cli`
+
+Provider run flags:
+
+- `--provider <name>`
+- `--model <name>`
+- `--reasoning <low|medium|high|max>`
+- `--provider-profile <name>`
+- `--provider-config key=value`
+- `--sandbox <read-only|workspace-write|danger-full-access>`
+- `--allow-write-dir <dir>`
+- `--trace-provider`
+
+Provider credentials and executable configuration live outside `.cml`.
+
+## JSON-RPC Bridge
+
+Start one bridge process per active host run:
+
+```sh
+opam exec -- dune exec camlflow -- serve --stdio
+```
+
+The bridge speaks JSON-RPC 2.0 over stdio with `Content-Length` framing.
+Hosts should send `initialize`, then `camlflow/check`, `camlflow/compile`, or
+`camlflow/run`. The server delegates effects back to the host with
+`camlflow/executeEffect`.
+
+Prefer the TypeScript SDK for host code:
+[`packages/camlflow-ts-json-rpc-sdk`](../packages/camlflow-ts-json-rpc-sdk).
+
+## Shell Completions
+
+```sh
+opam exec -- dune exec camlflow -- completion bash > /tmp/camlflow.bash
+opam exec -- dune exec camlflow -- completion zsh > /tmp/_camlflow
+opam exec -- dune exec camlflow -- completion fish > /tmp/camlflow.fish
+```
+
+## Troubleshooting
+
+If Dune reports that it cannot locate `camlflow` while several `dune exec`
+commands are running at the same time, rerun the command by itself or install
+the CLI into the active switch with `opam exec -- dune install camlflow`.
+
+If `check`, `compile`, or `run` uses the wrong file, rerun with an explicit
+source path and record the current working directory. The nearest
+`camlflow.json` may be supplying defaults.
+
+If JSON input fails to decode, check tagged variant and option encoding. Variants
+use `{ "tag": "Constructor" }`; constructors with payloads add `"value"`.
+For the full mapping from CamlFlow types to JSON shapes, see
+[`json-encoding.md`](./json-encoding.md).

--- a/docs/docs-validation.md
+++ b/docs/docs-validation.md
@@ -1,0 +1,159 @@
+# Documentation Validation
+
+Use this checklist when editing user-facing docs, examples, SDK READMEs, or
+editor README files. It is intentionally command-oriented so documentation can
+stay synchronized with the actual CLI, JSON encoding, project config, JSON-RPC
+bridge, and Pi SDK harness behavior.
+
+## Baseline
+
+Use the OCaml 5.4 switch for local validation:
+
+```sh
+opam install . --deps-only --with-test --yes --switch 5.4.0
+opam exec --switch 5.4.0 -- dune fmt
+opam exec --switch 5.4.0 -- dune test
+timeout 180s opam exec --switch 5.4.0 -- dune build
+```
+
+Then smoke the public CLI surfaces:
+
+```sh
+opam exec --switch 5.4.0 -- dune exec camlflow -- --help
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/basic/main.cml --input-json '"Ada"'
+timeout 2s opam exec --switch 5.4.0 -- dune exec camlflow -- serve --stdio
+```
+
+## Runnable Doc Snippets
+
+When a doc contains a source or input example, copy it into `/tmp` and run it
+through the actual CLI. Prefer explicit file paths for source examples:
+
+```sh
+opam exec --switch 5.4.0 -- dune exec camlflow -- check /tmp/example/main.cml
+opam exec --switch 5.4.0 -- dune exec camlflow -- run /tmp/example/main.cml --input /tmp/example/input.json
+```
+
+For config-backed examples outside the repository root, use the built binary.
+Nested `dune exec` can fail because it is no longer running from the workspace
+root:
+
+```sh
+CAMLFLOW_BIN="$(pwd)/_build/default/bin/main.exe"
+(cd /tmp/example && "$CAMLFLOW_BIN" check && "$CAMLFLOW_BIN" run --input input.json)
+```
+
+Remember:
+
+- `camlflow.json` uses `entry`, not `entrypoint`
+- `camlflow.json` does not store input paths
+- input payloads come from `--input` or `--input-json`
+- empty list literals often need type context, such as
+  `let goals : string list = []`
+
+## Checked-In Examples
+
+Run examples added or changed by the docs edit. For the first workflow example:
+
+```sh
+opam exec --switch 5.4.0 -- dune exec camlflow -- check examples/first-workflow/main.cml
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/first-workflow/main.cml \
+  --input examples/first-workflow/input.json
+
+CAMLFLOW_BIN="$(pwd)/_build/default/bin/main.exe"
+(cd examples/first-workflow && "$CAMLFLOW_BIN" check && "$CAMLFLOW_BIN" run --input input.json)
+```
+
+For structured examples:
+
+```sh
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/problem-coach/main.cml \
+  --skills examples/problem-coach/skills \
+  --input examples/problem-coach/input.json
+```
+
+## Markdown Links
+
+Run a scoped local-link check after adding or moving docs:
+
+```sh
+node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+const root = process.cwd();
+const starts = [
+  'README.md',
+  'docs',
+  'examples',
+  'packages/camlflow-pi-sdk/README.md',
+  'packages/camlflow-pi-sdk/examples/README.md',
+  'packages/camlflow-ts-json-rpc-sdk/README.md',
+  'packages/camlflow-ts-json-rpc-sdk/examples/README.md',
+  'packages/camlflow-vscode/README.md',
+  'packages/camlflow-zed/README.md',
+];
+const files = [];
+function walk(item) {
+  const full = path.join(root, item);
+  if (!fs.existsSync(full)) return;
+  const stat = fs.statSync(full);
+  if (stat.isDirectory()) {
+    for (const entry of fs.readdirSync(full, { withFileTypes: true })) {
+      if (['node_modules', 'dist', 'examples-dist', '_build', 'target'].includes(entry.name)) continue;
+      walk(path.join(item, entry.name));
+    }
+  } else if (stat.isFile() && item.endsWith('.md')) {
+    files.push(full);
+  }
+}
+starts.forEach(walk);
+const missing = [];
+for (const file of files) {
+  const text = fs.readFileSync(file, 'utf8');
+  const re = /\[[^\]\n]+\]\(([^\)\n]+)\)/g;
+  for (const match of text.matchAll(re)) {
+    let target = match[1].trim();
+    if (!target || target.startsWith('#') || /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(target)) continue;
+    target = target.replace(/^<|>$/g, '');
+    const noAnchor = target.split('#')[0];
+    if (!noAnchor) continue;
+    const resolved = path.resolve(path.dirname(file), decodeURI(noAnchor));
+    if (!fs.existsSync(resolved)) missing.push(`${path.relative(root, file)} -> ${target}`);
+  }
+}
+if (missing.length) {
+  console.error(missing.join('\n'));
+  process.exit(1);
+}
+console.log(`checked ${files.length} markdown files; all scoped local links resolve`);
+NODE
+```
+
+## Package Docs
+
+Run package-local checks when package docs or examples change:
+
+```sh
+(cd packages/camlflow-ts-json-rpc-sdk && npm install && opam exec --switch 5.4.0 -- npm test)
+(cd packages/camlflow-pi-sdk && npm install && opam exec --switch 5.4.0 -- npm test)
+(cd packages/camlflow-vscode && npm test)
+```
+
+Do not run the Pi SDK and JSON-RPC SDK tests in parallel when the Pi SDK reads
+the JSON-RPC SDK `dist` while the JSON-RPC SDK is rebuilding it.
+
+If `packages/camlflow-zed` changed, run `cargo check` when Rust tooling is
+available. In environments without `cargo`, record that as a blocked check.
+
+## Final Hygiene
+
+Before finishing a docs change:
+
+```sh
+git diff --check
+(cd packages/camlflow-pi-sdk && npm audit --omit=dev --json)
+ps -eo pid,ppid,command | rg '(/home/adminai/projects/camlflow|dune|camlflow|npm test|node --test|cargo check)'
+```
+
+The Pi SDK full dev install may still report moderate dev-only findings from
+the Pi dependency tree. The production audit above should remain clean.

--- a/docs/editor-support.md
+++ b/docs/editor-support.md
@@ -1,0 +1,185 @@
+# Editor Support
+
+CamlFlow ships editor integrations for `.cml` files and `camlflow.json`
+project configs. The editor packages do not execute workflows themselves; they
+start the CamlFlow language server and use the shared project-config schema.
+
+Use this guide to connect editor setup with the authoring and running docs.
+
+## What Editors Provide
+
+The current editor integrations provide:
+
+- `.cml` file association
+- syntax highlighting
+- block comments and bracket behavior
+- language-server diagnostics
+- hover, definition, references, rename, and document outline
+- `camlflow.json` schema validation
+
+Workflow execution still happens through the CLI, JSON-RPC host bridge, or Pi
+SDK harness:
+
+- [CLI reference](./cli-reference.md)
+- [Language reference](./language-reference.md)
+- [Glossary](./glossary.md)
+- [Pi SDK harness](./pi-sdk-harness.md)
+- [Writing and running CamlFlow](./writing-and-running-camlflow.md)
+
+## Language Server
+
+Both editor packages launch the same command:
+
+```sh
+camlflow lsp
+```
+
+The `camlflow` executable must be available on the editor process `PATH`. If
+the editor was launched from a desktop shell, its `PATH` may differ from your
+terminal.
+
+Check the language server from a terminal first:
+
+```sh
+camlflow --help
+camlflow lsp
+```
+
+The `lsp` command stays running until the editor stops it. For a quick terminal
+smoke, interrupt it with `Ctrl-C` after it starts.
+
+## VS Code
+
+The VS Code package lives in
+[`packages/camlflow-vscode`](../packages/camlflow-vscode/README.md).
+
+Build and test it locally:
+
+```sh
+cd packages/camlflow-vscode
+npm install
+npm test
+npm run package
+```
+
+For extension development, launch VS Code with the package as the extension
+development path:
+
+```sh
+code --extensionDevelopmentPath "$(pwd)"
+```
+
+If `camlflow` is not on the VS Code process `PATH`, override the LSP command in
+VS Code settings:
+
+```json
+{
+  "camlflow.lsp.command": "/absolute/path/to/camlflow",
+  "camlflow.lsp.args": ["lsp"]
+}
+```
+
+The package contributes JSON schema validation for files named
+`camlflow.json`, using the generated copy of the shared schema.
+
+## Zed
+
+The Zed package lives in
+[`packages/camlflow-zed`](../packages/camlflow-zed/README.md).
+
+Install it as a development extension:
+
+1. Open Zed.
+2. Run `zed: install dev extension`.
+3. Select `packages/camlflow-zed`.
+4. Open a `.cml` file.
+
+If `camlflow` is not on the Zed process `PATH`, configure the registered
+language server name, `camlflow-lsp`:
+
+```json
+{
+  "lsp": {
+    "camlflow-lsp": {
+      "binary": {
+        "path": "/absolute/path/to/camlflow",
+        "arguments": ["lsp"]
+      }
+    }
+  }
+}
+```
+
+Zed does not currently let this extension inject JSON schema associations
+directly. Copy the snippet from
+[`packages/camlflow-zed/settings/camlflow-json-schema-settings.jsonc`](../packages/camlflow-zed/settings/camlflow-json-schema-settings.jsonc)
+into your workspace or user settings to validate `camlflow.json`.
+
+## Project Config In Editors
+
+Editor validation and CLI execution share the same config shape:
+
+- canonical schema: [`schemas/camlflow.schema.json`](../schemas/camlflow.schema.json)
+- config reference: [`docs/project-config.md`](./project-config.md)
+
+The CLI finds the nearest `camlflow.json` when a command is run without an
+explicit file:
+
+```sh
+cd examples/project-config
+camlflow check
+camlflow run --input input.json
+```
+
+Editor diagnostics come from the language server for `.cml` files and from JSON
+schema validation for `camlflow.json`. If CLI and editor behavior disagree,
+verify which workspace folder the editor opened and which `camlflow` binary it
+starts.
+
+## Smoke Test
+
+After installing either editor integration:
+
+1. Open `examples/basic/main.cml`.
+2. Confirm the file is detected as CamlFlow.
+3. Confirm syntax highlighting is active.
+4. Hover over a declaration or reference.
+5. Run go-to-definition on a local symbol.
+6. Open `examples/project-config/camlflow.json`.
+7. Confirm schema validation or completion is available.
+8. Run the same workflow from a terminal:
+
+```sh
+camlflow run examples/basic/main.cml --input-json '"Ada"'
+```
+
+Expected output:
+
+```text
+steps: 1
+"!"
+```
+
+## Troubleshooting
+
+If the editor shows no LSP features:
+
+- run `camlflow --help` from the same shell used to launch the editor
+- configure the absolute LSP binary path
+- check the editor's language-server logs
+- run `camlflow check <file.cml>` from a terminal for the same file
+
+If `camlflow.json` validation is missing:
+
+- in VS Code, ensure the file is named exactly `camlflow.json`
+- in Zed, install the JSON language-server schema snippet
+- compare against the [project config reference](./project-config.md)
+
+If module diagnostics differ between editor and terminal:
+
+- check whether the terminal command used explicit `-I` include paths
+- check the nearest `camlflow.json`
+- prefer running from the same workspace root the editor opened
+
+See [Troubleshooting](./troubleshooting.md) for runtime, provider, JSON-RPC, and
+Pi SDK issues.

--- a/docs/first-workflow.md
+++ b/docs/first-workflow.md
@@ -1,0 +1,263 @@
+# First CamlFlow Workflow
+
+This tutorial starts with one `.cml` file, runs it locally, adds structured
+input, adds an effect, then shows where provider, JSON-RPC, and Pi harness runs
+fit.
+
+Use this when you want the shortest path from an empty file to a workflow you
+can run and host.
+
+The checked-in companion project is
+[`examples/first-workflow`](../examples/first-workflow).
+
+## Prerequisites
+
+Build CamlFlow from the repository first:
+
+```sh
+opam install . --deps-only --with-test --yes
+opam exec -- dune build
+```
+
+If your shell uses an older opam switch, pass the switch explicitly:
+
+```sh
+opam install . --deps-only --with-test --yes --switch 5.4.0
+opam exec --switch 5.4.0 -- dune build
+```
+
+All commands below assume you are in the repository root.
+
+For sections that run from `/tmp/camlflow-first`, capture the built CLI path:
+
+```sh
+CAMLFLOW_BIN="$(pwd)/_build/default/bin/main.exe"
+```
+
+## 1. Write A Pure Workflow
+
+Create `/tmp/camlflow-first/main.cml`:
+
+```ocaml
+let main (name : string) : string =
+  "Hello " ^ name
+```
+
+Check and run it:
+
+```sh
+opam exec -- dune exec camlflow -- check /tmp/camlflow-first/main.cml
+opam exec -- dune exec camlflow -- run /tmp/camlflow-first/main.cml --input-json '"Ada"'
+```
+
+Expected output:
+
+```text
+steps: 0
+"Hello Ada"
+```
+
+`check` loads and type-checks the workflow. `run` executes it.
+
+## 2. Use Structured Input
+
+Most real workflows should use one record argument. That keeps CLI, JSON-RPC,
+and Pi SDK calls predictable.
+
+Replace `/tmp/camlflow-first/main.cml`:
+
+```ocaml
+type request = {
+  name : string;
+  punctuation : string;
+}
+
+let main (request : request) : string =
+  "Hello " ^ request.name ^ request.punctuation
+```
+
+Run it with an inline JSON object:
+
+```sh
+opam exec -- dune exec camlflow -- run /tmp/camlflow-first/main.cml \
+  --input-json '{"name":"Ada","punctuation":"!"}'
+```
+
+Expected output:
+
+```text
+steps: 0
+"Hello Ada!"
+```
+
+For larger inputs, put the JSON in a file:
+
+```json
+{
+  "name": "Ada",
+  "punctuation": "!"
+}
+```
+
+Then run:
+
+```sh
+opam exec -- dune exec camlflow -- run /tmp/camlflow-first/main.cml \
+  --input /tmp/camlflow-first/input.json
+```
+
+See [JSON encoding](./json-encoding.md) for records, variants, options, tuples,
+and lists.
+
+## 3. Add An Effect
+
+Agents and skills are effects. Use `let*` when a workflow must wait for an
+effect result.
+
+Replace `/tmp/camlflow-first/main.cml`:
+
+```ocaml
+type request = {
+  name : string;
+  punctuation : string;
+}
+
+agent greeter : name:string -> string = Agent.bind "greeter"
+
+let main (request : request) : string =
+  let* greeting = greeter ~name:request.name in
+  greeting ^ request.punctuation
+```
+
+Run it locally:
+
+```sh
+opam exec -- dune exec camlflow -- run /tmp/camlflow-first/main.cml \
+  --input-json '{"name":"Ada","punctuation":"!"}'
+```
+
+With the deterministic local runtime, unresolved effects return placeholder
+JSON. That lets you validate parsing, typing, orchestration, and output
+decoding before wiring in a real provider or host.
+
+## 4. Add A Project Config
+
+For repeated runs, add `/tmp/camlflow-first/camlflow.json`:
+
+```json
+{
+  "program": "main.cml",
+  "entry": "main"
+}
+```
+
+Add `/tmp/camlflow-first/input.json`:
+
+```json
+{
+  "name": "Ada",
+  "punctuation": "!"
+}
+```
+
+Then run from the project directory:
+
+```sh
+cd /tmp/camlflow-first
+"$CAMLFLOW_BIN" check
+"$CAMLFLOW_BIN" run --input input.json
+```
+
+When no source file is provided, CamlFlow finds the nearest `camlflow.json`.
+Input still comes from `--input` or `--input-json`; project config does not
+store input payload paths.
+See [Project config](./project-config.md) for lookup rules and field
+precedence.
+
+## 5. Run With A Provider
+
+Provider-backed CLI runs are useful when you want a quick terminal-owned model
+execution path:
+
+```sh
+opam exec -- dune exec camlflow -- run /tmp/camlflow-first/main.cml \
+  --input /tmp/camlflow-first/input.json \
+  --provider codex \
+  --model gpt-5.4-mini \
+  --reasoning low \
+  --sandbox read-only
+```
+
+Provider runs require the provider CLI and credentials to be configured outside
+CamlFlow. Keep provider-specific credentials out of `.cml` files.
+
+See [Provider execution](./provider-execution.md) for providers, sandbox flags,
+model selection, and trace output.
+
+## 6. Host The Workflow Over JSON-RPC
+
+Use JSON-RPC when another process should own effect execution:
+
+```sh
+opam exec -- dune exec camlflow -- serve --stdio
+```
+
+The server speaks JSON-RPC 2.0 over stdio with `Content-Length` framing. A host
+initializes the bridge, runs a workflow, and handles effect requests.
+
+Start with:
+
+- [JSON-RPC protocol](./json-rpc.md)
+- [TypeScript JSON-RPC SDK](../packages/camlflow-ts-json-rpc-sdk/README.md)
+- [JSON-RPC host examples](../examples/json-rpc-host/README.md)
+
+## 7. Use The Pi SDK Harness
+
+Use the Pi SDK harness when host TypeScript wants a Flue-like API with one
+agent-owned sandbox, sessions, tasks, skills, shell access, and workflow runs.
+
+```ts
+import { createPiCamlFlowHarness } from "camlflow-pi-sdk";
+
+const harness = createPiCamlFlowHarness({ runtime });
+const agent = await harness.init({ sandbox: "workspace-write" });
+
+try {
+  const session = await agent.session("first-workflow");
+  const answer = await session.prompt("Summarize this workflow.");
+
+  const result = await agent.runWorkflow("/tmp/camlflow-first/main.cml", {
+    input: { name: "Ada", punctuation: "!" },
+  });
+
+  console.log(answer, result.output);
+} finally {
+  await agent.close();
+}
+```
+
+Use one agent per sandbox lifetime. Use separate sessions or `session.task(...)`
+for separate message histories. See [Pi SDK harness](./pi-sdk-harness.md) for
+sandbox presets, shell constraints, cancellation, lifecycle, and JSON contracts.
+
+## Development Loop
+
+A practical loop is:
+
+1. Write pure types and helper functions.
+2. Add agent or skill declarations only at the boundaries.
+3. Run `check` after syntax or type changes.
+4. Run deterministic CLI execution with representative JSON input.
+5. Add `camlflow.json` when command lines become repetitive.
+6. Add provider, JSON-RPC, or Pi harness execution only after the workflow
+   contract is stable.
+
+For more patterns, continue with:
+
+- [Workflow cookbook](./workflow-cookbook.md)
+- [Language reference](./language-reference.md)
+- [Glossary](./glossary.md)
+- [Run modes](./run-modes.md)
+- [Writing and running CamlFlow](./writing-and-running-camlflow.md)
+- [CLI reference](./cli-reference.md)
+- [Troubleshooting](./troubleshooting.md)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,196 @@
+# CamlFlow Glossary
+
+Use this glossary to keep terms consistent across `.cml` authoring, CLI runs,
+JSON-RPC hosts, provider adapters, and the Pi SDK harness.
+
+## Workflow
+
+A typed CamlFlow program. Workflows live in `.cml` files, type-check before
+execution, and usually expose a `main` entrypoint.
+
+```ocaml
+let main (name : string) : string =
+  "Hello " ^ name
+```
+
+## Entrypoint
+
+The top-level function selected for a run. The default entrypoint is `main`.
+The CLI flag is `--entry`; the project-config field is `entry`.
+
+```json
+{
+  "program": "main.cml",
+  "entry": "main"
+}
+```
+
+Input payloads are not stored in `camlflow.json`; pass them with `--input` or
+`--input-json`.
+
+## Pure Orchestration
+
+The part of a workflow that CamlFlow evaluates directly: type declarations,
+helper functions, branching, matching, records, variants, and other deterministic
+logic.
+
+Keep as much normalization and decision-making here as practical so effects
+receive typed, stable inputs.
+
+## Effect
+
+Host-executed work represented by an `agent` or `skill` declaration. Effects are
+sequenced with `let*`.
+
+```ocaml
+let* answer = reviewer ~code:code in
+answer
+```
+
+CamlFlow validates the JSON returned by an effect against the declared return
+type before the workflow continues.
+
+## Agent
+
+A typed effect intended for model-backed work. Agents can be bound by name:
+
+```ocaml
+agent reviewer : code:string -> string = Agent.bind "reviewer"
+```
+
+or defined inline with host-visible metadata:
+
+```ocaml
+agent reviewer : code:string -> string =
+  Agent.define ~name:"reviewer" ~system_prompt:"Review tersely."
+```
+
+## Skill
+
+A named prompt/tool behavior. In `.cml`, skills are declared with `Skill.bind`:
+
+```ocaml
+skill caveman : prompt:string -> string = Skill.bind "caveman"
+```
+
+For local prompt-backed skills, the CLI resolves
+`skills/<name>/SKILL.md` from the configured skills directory.
+
+## Deterministic Runtime
+
+The built-in local runtime used when no provider or host effect executor is
+configured. It returns placeholder JSON for unresolved effects and is useful for
+parser, type, module, JSON, and orchestration validation.
+
+It does not evaluate model quality.
+
+## Provider
+
+A direct CLI adapter for executing effects through an external coding/model CLI,
+such as `codex`, `opencode`, `claude-code`, or `claude-cli`.
+
+Providers own credentials, model calls, and tool behavior. CamlFlow owns the
+typed workflow contract and output validation.
+
+## Host
+
+An external process or application that owns effect execution. Hosts usually
+communicate with CamlFlow through JSON-RPC over stdio.
+
+Use one `camlflow serve --stdio` process per active run.
+
+## JSON-RPC Bridge
+
+The stdio protocol surface started by:
+
+```sh
+camlflow serve --stdio
+```
+
+It uses JSON-RPC 2.0 with `Content-Length` framing. The server sends
+`camlflow/executeEffect` requests to the host when a workflow reaches an effect.
+
+## Pi SDK Harness
+
+The CamlFlow-owned TypeScript package that wraps JSON-RPC workflow execution and
+Pi worker sessions:
+
+```ts
+const harness = createPiCamlFlowHarness({ runtime });
+const agent = await harness.init({ sandbox: "workspace-write" });
+```
+
+It provides a Flue-style API with agent-owned sandboxes, sessions, tasks, skill
+calls, trusted shell access where allowed, and workflow runs.
+
+## Session
+
+A Pi harness conversation context. Sessions share the agent sandbox but keep
+message history separate.
+
+Use separate sessions for separate conversations. Use `session.task(...)` for
+one-shot child sessions that should share the sandbox but not the parent message
+history.
+
+## Sandbox
+
+A host-selected execution boundary for Pi harness work. Built-in presets include
+`local`, `workspace-write`, `read-only`, and `ephemeral`.
+
+Sandbox policy controls tool availability and trusted shell behavior. Automatic
+directory cleanup is limited to `ephemeral` sandboxes.
+
+## Trusted Shell
+
+The host-side shell API exposed by the Pi harness when the selected sandbox
+allows it:
+
+```ts
+await session.shell("pwd");
+```
+
+The built-in local shell constrains `cwd` to the sandbox root and checks paths
+after symlink resolution.
+
+## Structured Output
+
+JSON returned by a provider, host, or Pi worker that must match a declared
+CamlFlow type.
+
+```ocaml
+type answer_pack = {
+  title : string;
+  next_steps : string list;
+}
+```
+
+If the JSON shape is wrong, CamlFlow fails at the effect boundary instead of
+letting later workflow steps consume invalid data.
+
+## Project Config
+
+`camlflow.json`, a project-local file for repeated CLI defaults such as
+`program`, `entry`, `includePaths`, `skillsDir`, provider fields, and sandbox
+flags.
+
+Config lookup searches upward from the current working directory. Explicit CLI
+flags take precedence over config fields.
+
+## Module
+
+A `.cml` file loaded by the project or include paths. Module resolution
+lowercases module paths and only resolves `.cml` modules, not arbitrary OCaml
+standard-library modules.
+
+```ocaml
+let payload : Helpers.payload = Helpers.make name
+```
+
+## More Detail
+
+- [First workflow](./first-workflow.md)
+- [Language reference](./language-reference.md)
+- [Run modes](./run-modes.md)
+- [Project config](./project-config.md)
+- [JSON encoding](./json-encoding.md)
+- [Pi SDK harness](./pi-sdk-harness.md)

--- a/docs/how-to-run-and-install.md
+++ b/docs/how-to-run-and-install.md
@@ -2,6 +2,25 @@
 
 This guide is for installing CamlFlow from this repository checkout and running
 the maintained CLI, JSON-RPC bridge, SDK examples, and editor integrations.
+For a map of all current and historical docs, see
+[`README.md`](./README.md).
+For `.cml` authoring patterns, JSON input shapes, and choosing between CLI,
+provider, JSON-RPC, and Pi harness execution, see
+[`writing-and-running-camlflow.md`](./writing-and-running-camlflow.md).
+For a step-by-step first workflow tutorial, see
+[`first-workflow.md`](./first-workflow.md).
+For a compact command and flag reference, see
+[`cli-reference.md`](./cli-reference.md).
+For `camlflow.json` fields and path resolution, see
+[`project-config.md`](./project-config.md).
+For JSON input and output encoding rules, see
+[`json-encoding.md`](./json-encoding.md).
+For VS Code and Zed language-server setup, see
+[`editor-support.md`](./editor-support.md).
+For Pi host integration and the Flue-style harness, see
+[`pi-sdk-harness.md`](./pi-sdk-harness.md).
+For common failures and fixes, see
+[`troubleshooting.md`](./troubleshooting.md).
 
 CamlFlow is not published here as a binary release. The supported local path is
 to clone the repository, install the OCaml dependencies with `opam`, and run the
@@ -17,6 +36,15 @@ Install these first:
 - Dune 3.22 or newer
 - Node.js 18 or newer for TypeScript SDK and editor packages
 - `npm` for packages under `packages/`
+
+The `dune` binary on your shell `PATH` may be older than the one installed in
+the opam switch. If `dune exec ...` reports that `(lang dune 3.22)` is not
+supported, run commands through the switch explicitly:
+
+```sh
+opam exec --switch 5.4.0 -- dune --version
+opam exec --switch 5.4.0 -- dune exec camlflow -- --help
+```
 
 The core package requires OCaml 5.4 or newer. If your default opam switch is
 older, create or select a compatible switch before installing dependencies:
@@ -74,6 +102,10 @@ opam exec -- dune exec camlflow -- run examples/recursion/main.cml --input-json 
 opam exec -- dune exec camlflow -- run examples/variants-match/main.cml
 ```
 
+For a guided path through pure workflows, local skills, project config,
+structured examples, JSON-RPC hosts, and Pi SDK harness examples, see
+[`examples/README.md`](../examples/README.md).
+
 The default runtime is deterministic. Bound agents and skills produce
 placeholder values until you configure a provider or host effect handler, so the
 basic example currently returns `"!"`.
@@ -101,6 +133,13 @@ Editor packages and external host tools expect this installed `camlflow`
 executable, or an equivalent wrapper, to be available on `PATH`.
 
 ## Common CLI Tasks
+
+For a fuller explanation of `.cml` syntax, `let*`, agents, skills, modules,
+JSON input encoding, provider-backed runs, and the Pi SDK harness, use the
+authoring guide:
+[`writing-and-running-camlflow.md`](./writing-and-running-camlflow.md).
+For exact command forms and flag precedence, use the CLI reference:
+[`cli-reference.md`](./cli-reference.md).
 
 Parse and type-check a source file:
 
@@ -227,6 +266,9 @@ This package wraps the JSON-RPC SDK and exposes two host-side APIs:
 - `createPiCamlFlowHarness(...).init({ sandbox, model })` for Flue-style
   `agent.session(...).prompt/skill/task/shell` orchestration
 
+The maintained Pi integration guide is
+[`pi-sdk-harness.md`](./pi-sdk-harness.md).
+
 Supported harness sandbox presets are `local` / `workspace-write`,
 `read-only`, `ephemeral`, and custom host-owned configs or factories. The
 package constrains trusted shell `cwd` values to the sandbox root and
@@ -272,7 +314,13 @@ See the package READMEs for editor-specific configuration:
 - [`packages/camlflow-vscode/README.md`](../packages/camlflow-vscode/README.md)
 - [`packages/camlflow-zed/README.md`](../packages/camlflow-zed/README.md)
 
+For a maintained editor setup and smoke-test guide, see
+[`editor-support.md`](./editor-support.md).
+
 ## Troubleshooting
+
+For the full troubleshooting guide, see
+[`troubleshooting.md`](./troubleshooting.md).
 
 ### `ocaml-base-compiler` conflict during `opam install`
 

--- a/docs/json-encoding.md
+++ b/docs/json-encoding.md
@@ -1,0 +1,230 @@
+# CamlFlow JSON Encoding
+
+CamlFlow uses explicit JSON encodings at every boundary:
+
+- CLI `--input` and `--input-json`
+- JSON-RPC `camlflow/run` input
+- JSON-RPC `camlflow/executeEffect` output
+- provider and Pi worker structured outputs
+
+For common decode failures and fixes, see
+[`troubleshooting.md`](./troubleshooting.md).
+
+The runtime decodes input JSON into the declared CamlFlow entrypoint type and
+validates effect outputs against the declared return type before the workflow
+continues.
+
+## Primitive Types
+
+| CamlFlow type | JSON shape |
+| --- | --- |
+| `string` | JSON string |
+| `int` | JSON integer |
+| `float` | JSON number; integers are accepted as floats |
+| `bool` | JSON boolean |
+| `unit` | `null` |
+
+Examples:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/basic/main.cml --input-json '"Ada"'
+opam exec -- dune exec camlflow -- run examples/recursion/main.cml --input-json '4'
+```
+
+## Records
+
+CamlFlow records encode as JSON objects with the declared field names:
+
+```ocaml
+type request = {
+  problem_name : string;
+  must_cover : string list;
+}
+```
+
+```json
+{
+  "problem_name": "two sum",
+  "must_cover": ["hash map approach", "time complexity"]
+}
+```
+
+Every declared field must be present. Do not use undeclared extra fields to
+carry workflow data; keep the `.cml` type and JSON payload aligned.
+
+## Lists And Tuples
+
+Lists encode as JSON arrays:
+
+```ocaml
+type request = { goals : string list }
+```
+
+```json
+{ "goals": ["map the main path", "identify risks"] }
+```
+
+Tuples also encode as JSON arrays, in tuple order:
+
+```ocaml
+let main (item : (string * int)) : string = "ok"
+```
+
+```json
+["priority", 1]
+```
+
+Tuple arrays must have exactly the declared arity.
+
+## Variants
+
+Variants encode as tagged objects.
+
+A nullary constructor uses only `tag`:
+
+```ocaml
+type language = Python | TypeScript | OCaml
+```
+
+```json
+{ "tag": "Python" }
+```
+
+A constructor with one payload uses `value`:
+
+```ocaml
+type focus = Pattern of string | Constraint of string
+```
+
+```json
+{ "tag": "Pattern", "value": "dynamic programming" }
+```
+
+A constructor with multiple payloads uses `values`:
+
+```ocaml
+type coordinate = Point of int * int
+
+let main (point : coordinate) : int =
+  match point with
+  | Point (x, y) -> x + y
+```
+
+```json
+{ "tag": "Point", "values": [3, 5] }
+```
+
+Constructor names are case-sensitive and must match the `.cml` declaration.
+
+## Options
+
+Options use the same tagged encoding as variants. They do not use bare `null`.
+
+```ocaml
+let main (note : string option) : string =
+  match note with
+  | Some text -> text
+  | None -> ""
+```
+
+```json
+{ "tag": "Some", "value": "extra context" }
+```
+
+```json
+{ "tag": "None" }
+```
+
+Use `null` only for `unit`, not for `None`.
+
+## Larger Example
+
+For this type:
+
+```ocaml
+type language = Python | TypeScript | OCaml
+type audience = Interview | Production
+
+type request = {
+  problem_name : string;
+  language : language;
+  audience : audience;
+  must_cover : string list;
+}
+```
+
+Use:
+
+```json
+{
+  "problem_name": "two sum",
+  "language": { "tag": "Python" },
+  "audience": { "tag": "Interview" },
+  "must_cover": [
+    "hash map approach",
+    "time complexity",
+    "duplicate values edge case"
+  ]
+}
+```
+
+Run the checked-in example:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/problem-coach/main.cml \
+  --skills examples/problem-coach/skills \
+  --input examples/problem-coach/input.json
+```
+
+## Shell Quoting
+
+Prefer `--input <file.json>` for records or nested values. Use `--input-json`
+for small values:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/basic/main.cml --input-json '"Ada"'
+opam exec -- dune exec camlflow -- run examples/recursion/main.cml --input-json '4'
+```
+
+When passing JSON objects inline, wrap the whole JSON value in single quotes so
+the shell does not consume double quotes:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/problem-coach/main.cml \
+  --skills examples/problem-coach/skills \
+  --input-json '{"problem_name":"two sum","language":{"tag":"Python"},"audience":{"tag":"Interview"},"must_cover":["hash map approach"]}'
+```
+
+For longer inputs, use a file instead.
+
+## Provider And Host Outputs
+
+Providers, JSON-RPC hosts, and Pi workers return JSON too. The same encoding
+rules apply to the declared return type of every effectful step.
+
+If an effect declares:
+
+```ocaml
+agent plan : request:request -> plan_result = Agent.bind "planner"
+```
+
+then the provider or host must return JSON matching `plan_result`. CamlFlow
+validates that JSON before later workflow steps can use it.
+
+## Common Decode Failures
+
+`JSON value does not match declared type`:
+The JSON shape does not match the expected primitive, list, tuple, record,
+variant, option, or unit shape.
+
+`missing JSON field <name>`:
+A record field declared in `.cml` is absent from the JSON object.
+
+`variant JSON requires a tag field`:
+A variant value must be an object with a string `tag`.
+
+`constructor payload missing value field`:
+A one-payload variant constructor needs `value`.
+
+`constructor payload missing values field`:
+A multi-payload variant constructor needs `values`.

--- a/docs/json-rpc.md
+++ b/docs/json-rpc.md
@@ -13,7 +13,16 @@ The goal of this phase is not to finalize every request payload, but to lock the
 - `docs/json-rpc-deferred-extensions.md` — formalized design-only notes for later protocol work
 - `docs/json-rpc-status.md` — current progress snapshot and fuller summary
 - `docs/json-rpc-checklist.md` — concise remaining-task checklist
+- `docs/writing-and-running-camlflow.md` — author-facing workflow guide before
+  host integration
+- `docs/cli-reference.md` — exact CLI forms for source, IR, and `serve --stdio`
+  runs
+- `docs/json-encoding.md` — CamlFlow type to JSON shape reference for run inputs
+  and effect outputs
+- `docs/pi-sdk-harness.md` — maintained Pi host-session and Flue-style harness
+  guide
 - `packages/camlflow-ts-json-rpc-sdk/README.md` — SDK guide and runnable client examples
+- `packages/camlflow-pi-sdk/README.md` — Pi adapter and Flue-style harness guide
 
 ---
 
@@ -32,6 +41,11 @@ The intended workflow is:
 - CamlFlow continues until final output is produced
 
 In this model, CamlFlow is a **typed orchestration engine**, not the owner of the surrounding tool UX.
+
+If you are deciding between integration surfaces, use direct CLI/provider runs
+for terminal validation, JSON-RPC when a host owns effect execution, and the Pi
+SDK harness when the host wants Flue-style agent sessions, sandbox ownership,
+trusted shell, and Pi skill orchestration.
 
 ---
 

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -1,0 +1,318 @@
+# CamlFlow Language Reference
+
+This is a compact reference for the `.cml` language surface that works today.
+CamlFlow intentionally looks like a small typed OCaml-style language, but it is
+not full OCaml.
+
+For a tutorial, start with [First workflow](./first-workflow.md). For runtime
+commands, see [CLI reference](./cli-reference.md). For input and output shapes,
+see [JSON encoding](./json-encoding.md).
+
+## Files And Modules
+
+A CamlFlow source file uses the `.cml` extension.
+
+```ocaml
+type payload = { name : string }
+
+let main (name : string) : string =
+  "Hello " ^ name
+```
+
+Each source file is a module. Module names come from file paths and are resolved
+from the main file plus include paths. For example:
+
+```text
+flow/
+  main.cml
+  helpers.cml
+```
+
+`main.cml` can refer to declarations from `helpers.cml` through `Helpers`:
+
+```ocaml
+let main (name : string) : string =
+  let payload : Helpers.payload = Helpers.make name in
+  payload.name
+```
+
+Use `open Helpers` when you want unqualified names from another loaded module.
+Only loaded `.cml` modules resolve; OCaml standard-library modules such as
+`List` are not available by module-qualified calls.
+
+## Declarations
+
+Top-level declarations include:
+
+- `type`
+- `let`
+- `let rec`
+- `agent`
+- `skill`
+- `open`
+
+```ocaml
+open Types
+
+type status = Ready | Blocked of string
+
+let rec sum_to (n : int) : int =
+  if n = 0 then 0 else n + sum_to (n - 1)
+
+agent reviewer : code:string -> string = Agent.bind "reviewer"
+
+skill caveman : prompt:string -> string = Skill.bind "caveman"
+```
+
+## Primitive Types
+
+Supported primitive types:
+
+- `string`
+- `int`
+- `float`
+- `bool`
+- `unit`
+
+```ocaml
+let message : string = "ok"
+let count : int = 3
+let ratio : float = 0.5
+let enabled : bool = true
+let done_value : unit = ()
+```
+
+`unit` encodes as JSON `null` at host boundaries.
+
+## Compound Types
+
+Records:
+
+```ocaml
+type request = {
+  name : string;
+  tags : string list;
+}
+```
+
+Variants:
+
+```ocaml
+type mode = Quick | DeepDive
+type focus = Pattern of string | Coordinate of int * int
+```
+
+Options:
+
+```ocaml
+let fallback (note : string option) : string =
+  match note with
+  | Some text -> text
+  | None -> ""
+```
+
+Tuples:
+
+```ocaml
+let first (pair : (string * int)) : string =
+  match pair with
+  | (name, _) -> name
+```
+
+Lists:
+
+```ocaml
+type request = { goals : string list }
+```
+
+For the exact JSON representation of each shape, see
+[JSON encoding](./json-encoding.md).
+
+## Expressions
+
+Common expressions:
+
+```ocaml
+let full = "Hello " ^ name in
+let next = count + 1 in
+let allowed = enabled && count > 0 in
+if allowed then full else "blocked"
+```
+
+Conditionals require a boolean condition and both branches must have the same
+type.
+
+Pattern matching is used for variants, options, and tuples:
+
+```ocaml
+let describe (mode : mode) : string =
+  match mode with
+  | Quick -> "quick"
+  | DeepDive -> "deep"
+```
+
+Matches must be exhaustive.
+
+## Functions
+
+Functions use annotated parameters and return types:
+
+```ocaml
+let greet (name : string) : string =
+  "Hello " ^ name
+```
+
+Multiple parameters are curried:
+
+```ocaml
+let surround (left : string) (right : string) (text : string) : string =
+  left ^ text ^ right
+```
+
+Recursive functions use `let rec`:
+
+```ocaml
+let rec sum_to (n : int) : int =
+  if n = 0 then 0 else n + sum_to (n - 1)
+```
+
+Entrypoints can have no arguments or one argument. For CLI, JSON-RPC, and Pi SDK
+host runs, one record argument is usually the most ergonomic shape.
+
+## Effects With Agents And Skills
+
+Agents and skills describe host-executed work. They are typed like functions,
+but calls are effectful.
+
+Use `Agent.bind` for a named external agent:
+
+```ocaml
+agent greeter : name:string -> string = Agent.bind "greeter"
+```
+
+Use `Skill.bind` for a named skill:
+
+```ocaml
+skill caveman : prompt:string -> string = Skill.bind "caveman"
+```
+
+Use `Agent.define` when the workflow should carry host-visible metadata:
+
+```ocaml
+agent reviewer : code:string -> string =
+  Agent.define
+    ~name:"reviewer"
+    ~model:"gpt-5.4-mini"
+    ~system_prompt:"Review the code tersely."
+```
+
+Calls to agents and skills must be sequenced with `let*`:
+
+```ocaml
+let main (name : string) : string =
+  let* greeting = greeter ~name:name in
+  greeting ^ "!"
+```
+
+The declared return type is enforced when the provider, JSON-RPC host, or Pi
+worker returns JSON.
+
+## Labeled Calls
+
+Agent and skill parameters are labeled:
+
+```ocaml
+agent planner : task:string -> goals:string list -> string list =
+  Agent.bind "planner"
+
+let main (task : string) : string list =
+  let goals : string list = ["find risks"; "propose checks"] in
+  let* plan = planner ~task:task ~goals:goals in
+  plan
+```
+
+Record fields use dot access:
+
+```ocaml
+let title (request : request) : string =
+  request.name
+```
+
+Record construction uses field assignment:
+
+```ocaml
+let make (name : string) : request =
+  { name = name; tags = [] }
+```
+
+Empty list literals need type context. Add an annotation when the type is not
+otherwise obvious:
+
+```ocaml
+let goals : string list = []
+```
+
+## Built-In Helpers
+
+CamlFlow includes a small helper surface for common workflow logic. Examples in
+this repository use:
+
+```ocaml
+is_some maybe_value
+unwrap_or maybe_value fallback
+```
+
+Use pattern matching when you need more control:
+
+```ocaml
+let describe (note : string option) : string =
+  match note with
+  | Some text -> text
+  | None -> "none"
+```
+
+## Operators
+
+Common operators include:
+
+- string concatenation: `^`
+- arithmetic: `+`, `-`, `*`, `/`
+- comparison: `=`, `<>`, `<`, `<=`, `>`, `>=`
+- boolean: `&&`, `||`
+
+Operator operands must type-check; CamlFlow does not coerce arbitrary values.
+
+## Comments And Formatting
+
+Block comments use OCaml-style delimiters:
+
+```ocaml
+(* Explain a workflow-specific invariant here. *)
+```
+
+Use `opam exec -- dune fmt` to format OCaml/Dune sources in this repository.
+The formatter check is part of the normal validation path.
+
+## Deliberate Limits
+
+CamlFlow is a workflow DSL, not a full OCaml runtime:
+
+- no arbitrary OCaml standard-library module calls such as `List.map`
+- no host shell access from `.cml` itself
+- no secret handling inside source files
+- provider, JSON-RPC, and Pi hosts own model execution and tools
+- `let*` is required for effect sequencing
+- project config does not store input payload paths; pass input with `--input`
+  or `--input-json`
+
+When in doubt, keep `.cml` responsible for typed orchestration and put tool use,
+credentials, and sandbox policy in the host or provider layer.
+
+## Next References
+
+- [First workflow](./first-workflow.md)
+- [Writing and running CamlFlow](./writing-and-running-camlflow.md)
+- [Workflow cookbook](./workflow-cookbook.md)
+- [JSON encoding](./json-encoding.md)
+- [Project config](./project-config.md)
+- [Pi SDK harness](./pi-sdk-harness.md)

--- a/docs/pi-mono-host-integration-plan.md
+++ b/docs/pi-mono-host-integration-plan.md
@@ -18,6 +18,7 @@ Why:
 
 Related docs:
 
+- `docs/pi-sdk-harness.md`
 - `docs/host-adapter-architecture.md`
 - `docs/pi-mono-implementation-checklist.md`
 - `docs/pi-mono-integration-testing.md`

--- a/docs/pi-mono-implementation-checklist.md
+++ b/docs/pi-mono-implementation-checklist.md
@@ -9,6 +9,7 @@ This is the concrete implementation checklist for the first real-host CamlFlow v
 
 It assumes the strategy already documented in:
 
+- `docs/pi-sdk-harness.md`
 - `docs/host-adapter-architecture.md`
 - `docs/pi-mono-host-integration-plan.md`
 - `docs/pi-mono-integration-testing.md`

--- a/docs/pi-mono-integration-testing.md
+++ b/docs/pi-mono-integration-testing.md
@@ -9,6 +9,7 @@ This document explains how to validate the CamlFlow ↔ `pi-mono` integration fr
 
 Related docs:
 
+- `docs/pi-sdk-harness.md`
 - `docs/pi-mono-host-integration-plan.md`
 - `docs/pi-mono-implementation-checklist.md`
 - `docs/json-rpc.md`

--- a/docs/pi-mono-manual-tests.md
+++ b/docs/pi-mono-manual-tests.md
@@ -14,6 +14,7 @@ what to type, and what the answer should look like.
 
 Related docs:
 
+- `docs/pi-sdk-harness.md`
 - `docs/pi-mono-host-integration-plan.md`
 - `docs/pi-mono-implementation-checklist.md`
 - `docs/pi-mono-integration-testing.md`

--- a/docs/pi-sdk-harness.md
+++ b/docs/pi-sdk-harness.md
@@ -1,0 +1,219 @@
+# CamlFlow Pi SDK Harness
+
+This is the maintained CamlFlow-owned integration path for Pi-style hosts. It
+uses `packages/camlflow-pi-sdk`, which wraps the JSON-RPC bridge and exposes two
+TypeScript APIs:
+
+- `createPiCamlFlowHostSession(...)` for running a known `.cml` workflow from a
+  native Pi command, palette action, panel, or other UI surface.
+- `createPiCamlFlowHarness(...)` for Flue-style agent orchestration with
+  sandbox ownership, named sessions, prompt/task/skill calls, trusted shell, and
+  workflow runs.
+
+The package does not parse `/camlflow-run` or own Pi UI registration. Pi or any
+other host owns commands, menus, panels, auth UX, and model selection.
+For the supported `.cml` syntax surface, see
+[`language-reference.md`](./language-reference.md).
+For common host, sandbox, and package-test failures, see
+[`troubleshooting.md`](./troubleshooting.md).
+
+## Choose The API
+
+Use `createPiCamlFlowHostSession(...)` when the host already knows the workflow
+path and wants to run it:
+
+```ts
+import { createPiCamlFlowHostSession } from "camlflow-pi-sdk";
+
+const host = createPiCamlFlowHostSession({ runtime });
+
+const result = await host.runWorkflow({
+  workflowPath: "examples/problem-coach/main.cml",
+  skillsDir: "examples/problem-coach/skills",
+  input: {
+    problem_name: "two sum",
+    language: { tag: "Python" },
+    audience: { tag: "Interview" },
+    must_cover: ["hash map approach", "time complexity"],
+  },
+});
+
+console.log(result.output);
+```
+
+Use `createPiCamlFlowHarness(...)` when the host wants a Flue-style agent object
+first:
+
+```ts
+import { createPiCamlFlowHarness } from "camlflow-pi-sdk";
+
+const harness = createPiCamlFlowHarness({ runtime });
+const agent = await harness.init({
+  id: "repo-triage",
+  sandbox: "workspace-write",
+  model: runtime.session.model,
+});
+
+const session = await agent.session("issue-42");
+
+try {
+  const findings = await session.task("Inspect this checkout and list risks.", {
+    result: "json",
+  });
+
+  const plan = await session.skill("triage", {
+    args: { issueNumber: 42, findings },
+    result: "json",
+  });
+
+  const workflow = await agent.runWorkflow({
+    workflowPath: "examples/repo-triage/main.cml",
+    skillsDir: "examples/repo-triage/skills",
+    input: {
+      task: "Triage the current repository.",
+      suspected_area: "Pi harness integration",
+      file_hints: [],
+      goals: ["ground findings in repository evidence"],
+      constraints: ["keep output actionable"],
+      mode: { tag: "Quick" },
+    },
+  });
+
+  console.log(plan, workflow.output);
+} finally {
+  await session.close();
+  await agent.close();
+}
+```
+
+## Runtime Boundary
+
+The host supplies Pi runtime services:
+
+- current working directory
+- current selected model and thinking level
+- model registry and auth storage
+- Pi session factory and tool services
+
+CamlFlow supplies:
+
+- `.cml` parsing, type-checking, and execution
+- JSON-RPC bridge lifecycle
+- effect metadata and output schema generation
+- validation of every provider/Pi worker JSON result
+
+Do not put credentials, sandbox policy, or shell commands in `.cml` prompts.
+Keep those in host code or `session.shell(...)`.
+
+## Sandboxes
+
+Harness presets:
+
+| Preset | Use |
+| --- | --- |
+| `local` | Alias for workspace-write local tools and trusted shell. |
+| `workspace-write` | Pi coding tools and trusted shell in the selected workspace. |
+| `read-only` | Read/search/list tools; `session.shell(...)` is disabled. |
+| `ephemeral` | Temporary workspace with tools and shell, removed on `agent.close()` unless cleanup is disabled. |
+
+Custom sandboxes can pass explicit `cwd`, `tools`, `shell`, and `dispose`.
+Sandbox factories can lazily create one sandbox per initialized agent:
+
+```ts
+const agent = await harness.init({
+  sandbox: async (cwd) => ({
+    kind: "custom",
+    cwd,
+    tools: () => myTools,
+    shell: myShellExecutor,
+    dispose: async () => {
+      await releaseResources();
+    },
+  }),
+});
+```
+
+The initialized `agent` owns the sandbox. Sessions share it. `session.close()`
+closes only the Pi conversation; `agent.close()` cancels active workflow runs
+and releases the sandbox.
+
+## Trusted Shell
+
+`session.shell(...)` is host-side trusted execution:
+
+```ts
+await session.shell("git status --short", {
+  cwd: ".",
+  timeoutMs: 10_000,
+});
+```
+
+Use it for explicit host commands and secret-bearing environment variables:
+
+```ts
+await session.shell("deploy-tool release", {
+  env: { DEPLOY_TOKEN: process.env.DEPLOY_TOKEN ?? "" },
+});
+```
+
+Built-in local shell sandboxes constrain `cwd` to the sandbox root, including
+symlink-aware filesystem checks. Shell commands must be non-empty. Environment
+maps must be plain objects with valid names and string values.
+
+## Workflow Inputs And Outputs
+
+`runWorkflow(...)`, `session.skill(..., { args })`, and parsed prompt results
+all use strict JSON values. CamlFlow type encoding rules are documented in
+[`json-encoding.md`](./json-encoding.md).
+
+Important shapes:
+
+- variants use `{ "tag": "Constructor" }`
+- one-payload variants use `{ "tag": "Constructor", "value": ... }`
+- multi-payload variants use `{ "tag": "Constructor", "values": [...] }`
+- options use `{ "tag": "Some", "value": ... }` or `{ "tag": "None" }`
+
+Pi workers must return JSON matching the declared CamlFlow return type for each
+effectful step. CamlFlow validates that JSON before the next workflow step runs.
+
+## Concurrency And Cancellation
+
+Rules:
+
+- one JSON-RPC bridge process handles one active CamlFlow run
+- one harness agent owns one sandbox
+- one session runs one prompt/skill turn at a time
+- use another session or `session.task(...)` for independent concurrent work
+- `session.abort()` cancels the active prompt turn and trusted shell command
+- `host.cancel()` or `agent.close()` cancels active workflow runs
+
+Host code should always close sessions and agents in `finally` blocks.
+
+## Examples
+
+Compile-checked examples live in
+[`packages/camlflow-pi-sdk/examples`](../packages/camlflow-pi-sdk/examples):
+
+- `command-runner.ts`: native Pi command/palette-style workflow run
+- `cancellation-and-streams.ts`: panel-style cancellation and output chunks
+- `flue-style-harness.ts`: sessions, skills, task, shell, sandbox, workflow run
+
+Run package validation:
+
+```sh
+cd packages/camlflow-pi-sdk
+npm install
+opam exec -- npm test
+```
+
+When your shell is not already on OCaml 5.4:
+
+```sh
+opam exec --switch 5.4.0 -- npm test
+```
+
+## Historical Pi Docs
+
+Older `pi-mono` documents in this repo describe the `/camlflow-run` prototype
+and manual launchers. They remain useful as historical validation notes, but new
+CamlFlow-side integration work should start from `packages/camlflow-pi-sdk`.

--- a/docs/project-config.md
+++ b/docs/project-config.md
@@ -1,0 +1,197 @@
+# CamlFlow Project Config
+
+`camlflow.json` lets a project pin repeated CLI defaults next to its `.cml`
+files. It is optional; every field can still be supplied explicitly through CLI
+flags or host SDK options.
+
+For install and run commands, see
+[`how-to-run-and-install.md`](./how-to-run-and-install.md). For CLI flags, see
+[`cli-reference.md`](./cli-reference.md).
+
+## Lookup And Precedence
+
+For `check`, `compile`, and `run`, CamlFlow searches from the current working
+directory upward for the nearest file named `camlflow.json`.
+
+Precedence is:
+
+1. explicit CLI flags
+2. nearest `camlflow.json`
+3. built-in defaults
+
+When debugging, use an explicit source path to avoid accidental nearest-config
+behavior:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/basic/main.cml --input-json '"Ada"'
+```
+
+## Minimal Config
+
+```json
+{
+  "program": "main.cml",
+  "entry": "main"
+}
+```
+
+From that directory:
+
+```sh
+opam exec -- dune exec camlflow -- check
+opam exec -- dune exec camlflow -- run --input input.json
+opam exec -- dune exec camlflow -- compile -o /tmp/main.ir.json
+```
+
+See [`examples/project-config`](../examples/project-config).
+
+## Full Shape
+
+```json
+{
+  "program": "main.cml",
+  "entry": "main",
+  "includePaths": ["."],
+  "skillsDir": "skills",
+  "provider": "codex",
+  "model": "gpt-5.4-mini",
+  "reasoning": "low",
+  "providerProfile": "work",
+  "providerConfig": {
+    "approval-policy": "never"
+  },
+  "sandbox": "workspace-write",
+  "allowWriteDirs": ["tmp"],
+  "traceProvider": false
+}
+```
+
+## Fields
+
+| Field | Type | Applies to | Notes |
+| --- | --- | --- | --- |
+| `program` | non-empty path string | `check`, `compile`, `run` | Source or artifact path used when the command omits a file argument. |
+| `entry` | string | `run` | Entrypoint name. Defaults to `main`. |
+| `includePaths` | non-empty path string array | `check`, `compile`, `run` | Extra `.cml` module search paths. |
+| `skillsDir` | non-empty path string | `run` | Root for local `skills/<name>/SKILL.md`. |
+| `provider` | string enum | `run` | `codex`, `opencode`, `claude-code`, or `claude-cli`. |
+| `model` | string | `run` | Provider model override when the workflow does not set one inline. |
+| `reasoning` | string enum | `run` | `low`, `medium`, `high`, or `max`. |
+| `providerProfile` | string | `run` | Provider-specific profile name. |
+| `providerConfig` | object of string values | `run` | Equivalent to repeated `--provider-config key=value`. Keys cannot be empty or contain `=`. |
+| `sandbox` | string enum | `run` | Direct CLI provider sandbox: `read-only`, `workspace-write`, or `danger-full-access`. |
+| `allowWriteDirs` | non-empty path string array | `run` | Extra writable directories for provider execution. |
+| `traceProvider` | boolean | `run` | Enables provider trace metadata. |
+
+Unknown fields are rejected.
+
+## Path Resolution
+
+Relative paths in these fields resolve from the directory containing
+`camlflow.json`:
+
+- `program`
+- `includePaths`
+- `skillsDir`
+- `allowWriteDirs`
+
+Absolute paths stay absolute. Empty path strings are rejected.
+
+Example:
+
+```text
+flows/
+  camlflow.json
+  src/main.cml
+  lib/types.cml
+```
+
+```json
+{
+  "program": "src/main.cml",
+  "includePaths": ["lib"]
+}
+```
+
+If the shell is in `flows/subdir`, the nearest config still resolves
+`src/main.cml` and `lib` relative to `flows/`.
+
+## Command-Specific Behavior
+
+`check` and `compile` use:
+
+- `program`
+- `includePaths`
+
+`run` uses:
+
+- `program`
+- `entry`
+- `includePaths`
+- `skillsDir`
+- provider fields
+
+Provider fields are not accepted by `check` or `compile`.
+
+## Provider Defaults
+
+Provider defaults in `camlflow.json` behave like CLI provider flags. This config:
+
+```json
+{
+  "program": "examples/codex/main.cml",
+  "skillsDir": "examples/codex/skills",
+  "provider": "codex",
+  "model": "gpt-5.4-mini",
+  "reasoning": "low",
+  "sandbox": "read-only",
+  "traceProvider": true
+}
+```
+
+is equivalent to:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/codex/main.cml \
+  --skills examples/codex/skills \
+  --provider codex \
+  --model gpt-5.4-mini \
+  --reasoning low \
+  --sandbox read-only \
+  --trace-provider
+```
+
+Provider credentials and executable setup still live outside `camlflow.json`.
+
+## Relationship To JSON-RPC And Pi SDK
+
+`camlflow.json` is a CLI/project convenience. JSON-RPC and Pi SDK hosts usually
+pass the same values explicitly:
+
+- JSON-RPC `program.path`
+- JSON-RPC `program.includePaths`
+- JSON-RPC `program.skillsDir`
+- Pi SDK `runWorkflow({ workflowPath, includePaths, skillsDir, ... })`
+
+Hosts can choose to read project config themselves, but the JSON-RPC protocol
+does not require that.
+
+## Common Errors
+
+`invalid field <name> ... unknown field`:
+Remove or rename the field. Config validation is strict.
+
+`invalid field provider ... unknown provider`:
+Use one of `codex`, `opencode`, `claude-code`, or `claude-cli`.
+
+`invalid field reasoning ... unknown reasoning level`:
+Use `low`, `medium`, `high`, or `max`.
+
+`invalid field sandbox ... unknown sandbox`:
+Use `read-only`, `workspace-write`, or `danger-full-access`.
+
+`invalid field allowWriteDirs[0] ... expected non-empty path`:
+Path fields and path-list entries cannot be empty strings.
+
+`invalid field providerConfig.foo ... expected string`:
+Every `providerConfig` value must be a string.

--- a/docs/provider-execution.md
+++ b/docs/provider-execution.md
@@ -31,7 +31,7 @@ camlflow run <file.cml|artifact.json> --provider codex ...
 Run from source:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/basic/main.cml \
+opam exec -- dune exec camlflow -- run examples/basic/main.cml \
   --input-json '"Ada"' \
   --provider codex \
   --model gpt-5.4-mini \
@@ -41,8 +41,8 @@ opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/basic/main.cml \
 Run from compiled IR:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- compile examples/basic/main.cml -o /tmp/basic.ir.json
-opam exec --switch 5.4.0 -- dune exec camlflow -- run /tmp/basic.ir.json \
+opam exec -- dune exec camlflow -- compile examples/basic/main.cml -o /tmp/basic.ir.json
+opam exec -- dune exec camlflow -- run /tmp/basic.ir.json \
   --input-json '"Ada"' \
   --provider codex \
   --model gpt-5.4-mini
@@ -189,7 +189,7 @@ The Claude Code and Claude CLI adapters behave the same way for unsupported inli
 Use `--trace-provider` to print provider-step metadata to `stderr`:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/basic/main.cml \
+opam exec -- dune exec camlflow -- run examples/basic/main.cml \
   --input-json '"Ada"' \
   --provider codex \
   --model gpt-5.4-mini \
@@ -314,7 +314,7 @@ This keeps failure modes explicit and easier to debug when integrating a new hos
 Codex:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
+opam exec -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider codex \
@@ -324,7 +324,7 @@ opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
 Opencode:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
+opam exec -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider opencode \
@@ -334,7 +334,7 @@ opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
 Claude Code:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
+opam exec -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider claude-code \
@@ -345,7 +345,7 @@ opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
 Claude CLI:
 
 ```sh
-ANTHROPIC_API_KEY=... opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
+ANTHROPIC_API_KEY=... opam exec -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider claude-cli \

--- a/docs/provider-execution.md
+++ b/docs/provider-execution.md
@@ -3,6 +3,12 @@
 CamlFlow can run with deterministic local defaults, or it can route unresolved
 agent/skill effects through an external provider.
 
+For the full authoring path from `.cml` scripts through deterministic CLI,
+provider CLI, JSON-RPC host mode, and the Pi SDK harness, see
+[`writing-and-running-camlflow.md`](./writing-and-running-camlflow.md).
+For the JSON shapes providers must return for declared CamlFlow types, see
+[`json-encoding.md`](./json-encoding.md).
+
 Beta 1 introduces an opt-in provider-backed execution path in the CLI.
 
 ## Current providers
@@ -25,7 +31,7 @@ camlflow run <file.cml|artifact.json> --provider codex ...
 Run from source:
 
 ```sh
-dune exec camlflow -- run examples/basic/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/basic/main.cml \
   --input-json '"Ada"' \
   --provider codex \
   --model gpt-5.4-mini \
@@ -35,8 +41,8 @@ dune exec camlflow -- run examples/basic/main.cml \
 Run from compiled IR:
 
 ```sh
-dune exec camlflow -- compile examples/basic/main.cml -o /tmp/basic.ir.json
-dune exec camlflow -- run /tmp/basic.ir.json \
+opam exec --switch 5.4.0 -- dune exec camlflow -- compile examples/basic/main.cml -o /tmp/basic.ir.json
+opam exec --switch 5.4.0 -- dune exec camlflow -- run /tmp/basic.ir.json \
   --input-json '"Ada"' \
   --provider codex \
   --model gpt-5.4-mini
@@ -183,7 +189,7 @@ The Claude Code and Claude CLI adapters behave the same way for unsupported inli
 Use `--trace-provider` to print provider-step metadata to `stderr`:
 
 ```sh
-dune exec camlflow -- run examples/basic/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/basic/main.cml \
   --input-json '"Ada"' \
   --provider codex \
   --model gpt-5.4-mini \
@@ -308,7 +314,7 @@ This keeps failure modes explicit and easier to debug when integrating a new hos
 Codex:
 
 ```sh
-dune exec camlflow -- run examples/codex/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider codex \
@@ -318,7 +324,7 @@ dune exec camlflow -- run examples/codex/main.cml \
 Opencode:
 
 ```sh
-dune exec camlflow -- run examples/codex/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider opencode \
@@ -328,7 +334,7 @@ dune exec camlflow -- run examples/codex/main.cml \
 Claude Code:
 
 ```sh
-dune exec camlflow -- run examples/codex/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider claude-code \
@@ -339,7 +345,7 @@ dune exec camlflow -- run examples/codex/main.cml \
 Claude CLI:
 
 ```sh
-ANTHROPIC_API_KEY=... dune exec camlflow -- run examples/codex/main.cml \
+ANTHROPIC_API_KEY=... opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider claude-cli \

--- a/docs/provider-hooks.md
+++ b/docs/provider-hooks.md
@@ -8,6 +8,9 @@ The built-in CLI providers (`codex`, `opencode`, `claude-code`, and
 `claude-cli`) are layered on top of the same runtime invocation metadata shown
 here. For the CLI-facing execution flow and provider-specific behavior, see
 `docs/provider-execution.md`.
+For author-facing `.cml` examples before embedding hooks, see
+`docs/writing-and-running-camlflow.md`; for exact command forms, see
+`docs/cli-reference.md`.
 
 ## Available runtime hooks
 

--- a/docs/run-modes.md
+++ b/docs/run-modes.md
@@ -1,0 +1,145 @@
+# Run Modes
+
+CamlFlow workflows can run in four practical modes. The `.cml` contract stays
+the same; the difference is who handles effects such as agents and skills.
+
+Use this guide when deciding how to execute a workflow after it type-checks.
+
+## Summary
+
+| Mode | Best for | Effect executor |
+| --- | --- | --- |
+| Deterministic CLI | authoring, parser/type/runtime checks, CI smoke | built-in placeholder runtime |
+| Provider CLI | quick terminal-owned model runs | configured provider CLI |
+| JSON-RPC host | custom applications and non-Pi hosts | host process callback |
+| Pi SDK harness | Flue-style Pi agent orchestration | Pi worker session in a sandbox |
+
+## Deterministic CLI
+
+Use deterministic CLI runs first. They are fast, local, and do not require model
+credentials.
+
+```sh
+opam exec -- dune exec camlflow -- check examples/first-workflow/main.cml
+opam exec -- dune exec camlflow -- run examples/first-workflow/main.cml \
+  --input examples/first-workflow/input.json
+```
+
+What this validates:
+
+- source parsing
+- type checking
+- module resolution
+- JSON input decoding
+- effect sequencing
+- final output validation
+
+What it does not validate:
+
+- model quality
+- provider credentials
+- host tool access
+- Pi sandbox behavior
+
+Bound agents and skills return deterministic placeholder JSON, so an effectful
+workflow may return a syntactically valid but semantically empty value.
+
+## Provider CLI
+
+Use provider CLI runs when you want a terminal command to own real model
+execution.
+
+```sh
+opam exec -- dune exec camlflow -- run examples/codex/main.cml \
+  --skills examples/codex/skills \
+  --input-json '"Ada"' \
+  --provider codex \
+  --model gpt-5.4-mini \
+  --reasoning low \
+  --sandbox read-only \
+  --trace-provider
+```
+
+This mode is useful for local end-to-end smoke tests and prompt iteration.
+CamlFlow still owns typed orchestration and output validation, but the provider
+CLI owns model execution, credentials, and tool behavior.
+
+Use provider config only for host/runtime settings. Keep secrets out of `.cml`
+files and committed `camlflow.json`.
+
+See [Provider execution](./provider-execution.md) for provider names, sandbox
+flags, model selection, unsupported inline settings, and trace output.
+
+## JSON-RPC Host
+
+Use JSON-RPC host mode when another process should own effect execution.
+
+```sh
+opam exec -- dune exec camlflow -- serve --stdio
+```
+
+The bridge speaks JSON-RPC 2.0 over stdio with `Content-Length` framing. A host
+initializes the bridge, starts a run, handles `camlflow/executeEffect`, and
+returns JSON matching the declared effect return type.
+
+Use one server process per active run. The current bridge is single-active-run
+by design.
+
+Start with:
+
+- [JSON-RPC protocol](./json-rpc.md)
+- [TypeScript JSON-RPC SDK](../packages/camlflow-ts-json-rpc-sdk/README.md)
+- [JSON-RPC host example](../examples/json-rpc-host/README.md)
+
+## Pi SDK Harness
+
+Use the Pi SDK harness when TypeScript host code wants a Flue-style API:
+
+```ts
+const harness = createPiCamlFlowHarness({ runtime });
+const agent = await harness.init({ sandbox: "workspace-write" });
+
+try {
+  const session = await agent.session("triage");
+  const answer = await session.prompt("Summarize the current repo.");
+
+  const result = await agent.runWorkflow("examples/repo-triage/main.cml", {
+    skillsDir: "examples/repo-triage/skills",
+    input: {
+      task: "Find integration risks.",
+      suspected_area: "Pi SDK harness",
+      file_hints: ["packages/camlflow-pi-sdk/src/index.ts"],
+      goals: ["map the entrypoints"],
+      constraints: ["use concrete file paths"],
+      mode: { tag: "QuickScan" },
+    },
+  });
+
+  console.log(answer, result.output);
+} finally {
+  await agent.close();
+}
+```
+
+The harness owns a sandbox for the agent lifetime. Sessions share that sandbox
+but keep message history separate. Use `session.task(...)` for one-shot child
+sessions and `session.shell(...)` only where the sandbox allows trusted shell
+execution.
+
+See [Pi SDK harness](./pi-sdk-harness.md) for sandbox presets, shell
+constraints, cancellation, lifecycle, result parsing, and JSON contracts.
+
+## Choosing A Mode
+
+Use this order when bringing up a workflow:
+
+1. `check` the source.
+2. Run deterministic CLI execution with representative JSON input.
+3. Add `camlflow.json` only for stable repeated defaults.
+4. Use provider CLI for terminal-owned model smoke tests.
+5. Use JSON-RPC for application-owned effect execution.
+6. Use Pi SDK harness for Flue-style agent sessions and sandboxed Pi workflows.
+
+If a workflow fails before the first effect, fix `.cml`, config, or input JSON.
+If it fails at an effect boundary, inspect the provider, host, or Pi worker
+output against [JSON encoding](./json-encoding.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,277 @@
+# CamlFlow Troubleshooting
+
+This guide collects the common failure modes when writing, running, hosting, or
+embedding CamlFlow workflows.
+
+For the happy path, start with:
+
+- [`how-to-run-and-install.md`](./how-to-run-and-install.md)
+- [`first-workflow.md`](./first-workflow.md)
+- [`language-reference.md`](./language-reference.md)
+- [`writing-and-running-camlflow.md`](./writing-and-running-camlflow.md)
+- [`run-modes.md`](./run-modes.md)
+- [`glossary.md`](./glossary.md)
+- [`cli-reference.md`](./cli-reference.md)
+- [`json-encoding.md`](./json-encoding.md)
+- [`pi-sdk-harness.md`](./pi-sdk-harness.md)
+
+## Opam Switch Is Too Old
+
+Symptom:
+
+```text
+CamlFlow requires OCaml >= 5.4
+```
+
+Fix:
+
+```sh
+opam switch create 5.4.0 ocaml-base-compiler.5.4.0
+opam install . --deps-only --with-test --yes --switch 5.4.0
+opam exec --switch 5.4.0 -- dune build
+```
+
+You can avoid changing your shell by adding `--switch 5.4.0` to `opam exec`
+commands:
+
+```sh
+opam exec --switch 5.4.0 -- dune exec camlflow -- --help
+```
+
+## Dune Cannot Locate `camlflow`
+
+Symptom:
+
+```text
+Warning: As this is not the main instance of Dune it is unable to locate the
+executable "camlflow" within this project.
+Error: Program 'camlflow' not found!
+```
+
+This can happen when several `dune exec camlflow` commands run concurrently
+from nested working directories.
+
+Fix:
+
+- rerun the command by itself, or
+- install the CLI into the active switch:
+
+```sh
+opam exec --switch 5.4.0 -- dune install camlflow
+eval "$(opam env --switch 5.4.0)"
+camlflow --help
+```
+
+## Dune Language 3.22 Is Not Supported
+
+Symptom:
+
+```text
+File "dune-project", line 1, characters 11-15:
+1 | (lang dune 3.22)
+               ^^^^
+Error: Version 3.22 of the dune language is not supported.
+```
+
+Your shell is running an older `dune` binary than this repository requires. The
+project needs Dune 3.22 or newer; older binaries such as Dune 3.14 stop before
+they can run any CamlFlow command.
+
+Fix by running through the opam switch that has the repo dependencies:
+
+```sh
+opam exec --switch 5.4.0 -- dune --version
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/repo-triage/main.cml \
+  --skills examples/repo-triage/skills \
+  --input examples/repo-triage/input.json
+```
+
+Or activate the switch in your shell:
+
+```sh
+eval "$(opam env --switch 5.4.0)"
+dune --version
+dune exec camlflow -- --help
+```
+
+## `check`, `compile`, Or `run` Used The Wrong File
+
+`check`, `compile`, and `run` can omit a source path when the nearest
+`camlflow.json` supplies `program`. If a command behaves differently from a
+previous run, record the current working directory and rerun with an explicit
+file path:
+
+```sh
+opam exec --switch 5.4.0 -- dune exec camlflow -- check examples/basic/main.cml
+```
+
+Config precedence is:
+
+1. explicit CLI flags
+2. nearest `camlflow.json`
+3. built-in defaults
+
+For the full config field reference, see
+[`project-config.md`](./project-config.md).
+
+## Module Or Qualified Name Is Unbound
+
+Likely causes:
+
+- the `.cml` file is not in the project or include path
+- the module path casing does not match CamlFlow's lowercase resolution
+- the code is using OCaml stdlib modules such as `List.map`
+
+CamlFlow only resolves loaded `.cml` modules. It is not full OCaml.
+
+Useful checks:
+
+```sh
+opam exec --switch 5.4.0 -- dune exec camlflow -- check examples/qualified-imports/main.cml \
+  -I examples/qualified-imports
+```
+
+## JSON Input Does Not Decode
+
+Symptoms:
+
+```text
+JSON value does not match declared type
+missing JSON field ...
+variant JSON requires a tag field
+constructor payload missing value field
+```
+
+Fix the JSON shape to match the declared `.cml` type:
+
+- records are JSON objects with every declared field
+- lists and tuples are JSON arrays
+- variants use `{ "tag": "Constructor" }`
+- one-payload variants use `{ "tag": "Constructor", "value": ... }`
+- multi-payload variants use `{ "tag": "Constructor", "values": [...] }`
+- options use `{ "tag": "Some", "value": ... }` or `{ "tag": "None" }`
+- `null` is only for `unit`
+
+For larger inputs, prefer `--input file.json` over inline shell JSON.
+
+## Deterministic Runs Return Empty Placeholder Values
+
+Symptom:
+
+```text
+steps: 1
+"!"
+```
+
+The default runtime is deterministic. Bound agents and skills return synthesized
+placeholder JSON until a provider, JSON-RPC host, or Pi worker handles the
+effect.
+
+Use deterministic runs for parser/type/runtime validation. Use one of these for
+real model execution:
+
+- direct provider CLI: `--provider codex`, `--provider opencode`,
+  `--provider claude-code`, or `--provider claude-cli`
+- JSON-RPC host mode with `camlflow serve --stdio`
+- Pi SDK host session or Flue-style harness
+
+## Provider Run Fails Before The First Effect
+
+Likely causes:
+
+- provider executable is not on `PATH`
+- provider credentials are not configured
+- model name is not accepted by that provider
+- inline `Agent.define` settings are unsupported by the selected provider
+
+Start with:
+
+```sh
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
+  --skills examples/codex/skills \
+  --input-json '"Ada"' \
+  --provider codex \
+  --model gpt-5.4-mini \
+  --trace-provider
+```
+
+Use [`provider-execution.md`](./provider-execution.md) for provider-specific
+preflight behavior.
+
+## Provider Or Host Returned Invalid Output
+
+CamlFlow validates every provider/host/Pi worker result against the declared
+return type. The fix is usually in the provider prompt, host effect handler, or
+Pi worker final JSON, not in the later workflow step.
+
+Check:
+
+- the effect name and declared return type
+- the generated schema in provider traces or JSON-RPC `executeEffect`
+- the JSON encoding rules in [`json-encoding.md`](./json-encoding.md)
+
+## JSON-RPC Host Appears Stuck
+
+The bridge is single-active-run by design. Start one `camlflow serve --stdio`
+process per active run.
+
+Host flow:
+
+1. send `initialize`
+2. send `camlflow/run`
+3. answer each `camlflow/executeEffect`
+4. read the final `camlflow/run` result
+5. send `shutdown` and `exit`
+
+If the host never answers `camlflow/executeEffect`, the workflow waits for that
+effect response.
+
+## Pi Harness Cannot Run A Shell Command
+
+Likely causes:
+
+- selected sandbox is `read-only`
+- shell `cwd` escapes the sandbox root
+- shell `cwd` resolves through a symlink outside the sandbox
+- command is empty
+- environment map has invalid names or non-string values
+
+Use `workspace-write` or `local` for trusted shell access:
+
+```ts
+const agent = await harness.init({ sandbox: "workspace-write" });
+const session = await agent.session("work");
+await session.shell("git status --short", { cwd: "." });
+```
+
+## Pi Harness Reuses Or Leaks State
+
+Lifecycle rules:
+
+- one initialized agent owns one sandbox
+- sessions share that sandbox
+- `session.close()` closes the Pi conversation only
+- `agent.close()` cancels active workflow runs and releases the sandbox
+- `session.task(...)` creates a one-shot child session with separate message
+  history
+
+Always close sessions and agents in `finally` blocks.
+
+## Package Tests Race
+
+The Pi SDK tests read the built JSON-RPC SDK package. Running both package test
+suites concurrently can race while the JSON-RPC SDK rebuilds its `dist`.
+
+Run them sequentially:
+
+```sh
+(cd packages/camlflow-ts-json-rpc-sdk && npm install && opam exec --switch 5.4.0 -- npm test)
+(cd packages/camlflow-pi-sdk && npm install && opam exec --switch 5.4.0 -- npm test)
+```
+
+## Pi SDK Audit Output
+
+`npm audit --omit=dev --json` is the production dependency check used for the
+Pi SDK package. Full dev installs may still report moderate findings from the
+Pi dependency tree; review upstream Pi updates before taking semver-major audit
+fixes.

--- a/docs/workflow-cookbook.md
+++ b/docs/workflow-cookbook.md
@@ -1,0 +1,290 @@
+# CamlFlow Workflow Cookbook
+
+Use these patterns as starting points for `.cml` workflows. For the language
+walkthrough, see [`writing-and-running-camlflow.md`](./writing-and-running-camlflow.md).
+For JSON input shapes, see [`json-encoding.md`](./json-encoding.md).
+
+## Small Bound Agent
+
+Use this when a host, provider, or Pi worker should implement the effect:
+
+```ocaml
+agent greeter : name:string -> string = Agent.bind "greeter"
+
+let main (name : string) : string =
+  let* greeting = greeter ~name:name in
+  greeting ^ "!"
+```
+
+Run deterministically while authoring:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/basic/main.cml --input-json '"Ada"'
+```
+
+Then add a provider or host when you want real model execution.
+
+## Pure Helpers Before Effects
+
+Keep normalization and branching in `.cml` so host effects receive clean inputs:
+
+```ocaml
+type language = Python | TypeScript | OCaml
+
+type request = {
+  problem_name : string;
+  language : language;
+}
+
+type normalized_request = {
+  title : string;
+  language_name : string;
+}
+
+let language_name (language : language) : string =
+  match language with
+  | Python -> "Python"
+  | TypeScript -> "TypeScript"
+  | OCaml -> "OCaml"
+
+let normalize (request : request) : normalized_request =
+  {
+    title = request.problem_name;
+    language_name = language_name request.language;
+  }
+```
+
+## Local Prompt Skill
+
+Use local skills when prompt behavior should live next to the project:
+
+```ocaml
+skill caveman : prompt:string -> string = Skill.bind "caveman"
+
+let main (prompt : string) : string =
+  let* answer = caveman ~prompt:prompt in
+  answer
+```
+
+Layout:
+
+```text
+skills/
+  caveman/
+    SKILL.md
+```
+
+Run:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/local-skill/main.cml \
+  --skills examples/local-skill/skills \
+  --input-json '"hello"'
+```
+
+## Inline Agent Metadata
+
+Use `Agent.define` when the workflow contract should carry agent metadata:
+
+```ocaml
+agent reviewer : code:string -> string =
+  Agent.define
+    ~name:"reviewer"
+    ~style:"concise"
+    ~system_prompt:"Review the code and return the requested JSON."
+```
+
+Provider and JSON-RPC/Pi hosts receive that metadata in the effect request.
+Inline `~model:"..."` wins over CLI `--model` for direct provider runs.
+
+## Structured Output Pack
+
+Declare the return type you want the provider or host to produce:
+
+```ocaml
+type answer_pack = {
+  title : string;
+  summary : string;
+  risks : string list;
+  next_steps : string list;
+}
+
+agent packager : prompt:string -> answer_pack = Agent.bind "packager"
+
+let main (prompt : string) : answer_pack =
+  let* pack = packager ~prompt:prompt in
+  pack
+```
+
+The provider/host/Pi worker must return JSON matching `answer_pack`. CamlFlow
+validates the shape before returning from `let*`.
+
+## Branching Between Effects
+
+Use pure branching to decide which effect to run:
+
+```ocaml
+type mode = Quick | DeepDive
+
+agent quick_triage : task:string -> string = Agent.bind "quick-triage"
+agent deep_triage : task:string -> string = Agent.bind "deep-triage"
+
+let main (task : string) (mode : mode) : string =
+  match mode with
+  | Quick ->
+      let* answer = quick_triage ~task:task in
+      answer
+  | DeepDive ->
+      let* answer = deep_triage ~task:task in
+      answer
+```
+
+Input:
+
+```json
+{ "tag": "Quick" }
+```
+
+If your entrypoint has more than one argument, hosts should call it through
+compiled IR or a wrapper that supplies labeled inputs. For CLI authoring,
+prefer one record argument for structured workflows.
+
+## One Record Argument For CLI And Hosts
+
+For CLI, JSON-RPC, and Pi SDK runs, one record argument is usually the most
+ergonomic entrypoint shape:
+
+```ocaml
+type mode = Quick | DeepDive
+
+type triage_request = {
+  task : string;
+  file_hints : string list;
+  mode : mode;
+}
+
+agent triager : request:triage_request -> string = Agent.bind "triager"
+
+let main (request : triage_request) : string =
+  let* answer = triager ~request:request in
+  answer
+```
+
+Input:
+
+```json
+{
+  "task": "Find likely regression risks.",
+  "file_hints": ["lib/runtime/runtime.ml", "packages/camlflow-pi-sdk/src/index.ts"],
+  "mode": { "tag": "Quick" }
+}
+```
+
+## Multi-File Project
+
+Split larger workflows into modules:
+
+```text
+my-flow/
+  camlflow.json
+  main.cml
+  types.cml
+  helpers.cml
+  skills/
+    triage/
+      SKILL.md
+```
+
+Use `open Types` or qualified names:
+
+```ocaml
+open Types
+
+let main (request : triage_request) : report =
+  Helpers.empty_report request.task
+```
+
+`camlflow.json`:
+
+```json
+{
+  "program": "main.cml",
+  "entry": "main",
+  "includePaths": ["."],
+  "skillsDir": "skills"
+}
+```
+
+Run from the project directory:
+
+```sh
+opam exec -- dune exec camlflow -- check
+opam exec -- dune exec camlflow -- run --input input.json
+```
+
+## Provider Debug Loop
+
+When a provider-backed run fails, keep the `.cml` workflow stable and inspect
+the effect boundary:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/codex/main.cml \
+  --skills examples/codex/skills \
+  --input-json '"Ada"' \
+  --provider codex \
+  --model gpt-5.4-mini \
+  --trace-provider
+```
+
+Look at:
+
+- effect kind and name
+- declared return type
+- generated schema
+- provider stderr
+- JSON returned by the provider
+
+## Pi Harness Wrapper
+
+Use `.cml` for typed workflow shape and the Pi harness for sandbox/session/shell
+orchestration:
+
+```ts
+const agent = await harness.init({ sandbox: "workspace-write" });
+const session = await agent.session("triage");
+
+try {
+  const prep = await session.task("Inspect the checkout and identify risk areas.", {
+    result: "json",
+  });
+
+  const workflow = await agent.runWorkflow({
+    workflowPath: "examples/repo-triage/main.cml",
+    skillsDir: "examples/repo-triage/skills",
+    input: {
+      task: "Triage the current repository.",
+      suspected_area: "runtime and Pi harness",
+      file_hints: [],
+      goals: ["ground findings in repository evidence"],
+      constraints: ["return actionable next steps"],
+      mode: { tag: "Quick" },
+    },
+  });
+
+  console.log(prep, workflow.output);
+} finally {
+  await session.close();
+  await agent.close();
+}
+```
+
+## What To Avoid
+
+- Do not rely on OCaml stdlib module calls such as `List.map`; only loaded
+  `.cml` modules resolve.
+- Do not hide credentials or shell commands inside prompts.
+- Do not use `null` for `None`; use `{ "tag": "None" }`.
+- Do not assume one JSON-RPC `serve --stdio` process can run multiple workflows
+  concurrently.
+- Do not use one Pi harness session for overlapping prompt/skill turns; open
+  another session or use `session.task(...)`.

--- a/docs/writing-and-running-camlflow.md
+++ b/docs/writing-and-running-camlflow.md
@@ -1,0 +1,465 @@
+# Writing And Running CamlFlow Workflows
+
+This guide is the author-facing path for writing `.cml` workflows and choosing
+the right execution mode now that CamlFlow has both direct CLI execution and the
+Pi SDK Flue-style harness.
+
+Use this guide after the repository is built. For setup commands, see
+[`how-to-run-and-install.md`](./how-to-run-and-install.md).
+For a step-by-step tutorial from an empty file, see
+[`first-workflow.md`](./first-workflow.md).
+For a compact syntax and declaration reference, see
+[`language-reference.md`](./language-reference.md).
+For copyable workflow patterns, see
+[`workflow-cookbook.md`](./workflow-cookbook.md).
+For an execution-mode comparison, see
+[`run-modes.md`](./run-modes.md).
+For shared terminology, see
+[`glossary.md`](./glossary.md).
+For a compact command and flag reference, see
+[`cli-reference.md`](./cli-reference.md).
+For common failures and fixes, see
+[`troubleshooting.md`](./troubleshooting.md).
+
+## Mental Model
+
+CamlFlow splits a workflow into two parts:
+
+- pure typed orchestration in `.cml`
+- effect execution by a host, provider, or Pi agent
+
+CamlFlow owns parsing, type-checking, module loading, effect metadata, JSON
+encoding, and output validation. The host owns model execution, tool use,
+credentials, sandbox policy, and user experience.
+
+That means a CamlFlow script should describe the workflow contract and sequencing
+clearly. It should not hide provider-specific shell commands or secret handling
+inside prompts.
+
+## Pick An Execution Mode
+
+Use deterministic CLI runs while developing pure logic or checking that a
+workflow type-checks:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/basic/main.cml --input-json '"Ada"'
+```
+
+Use provider-backed CLI runs when you want quick end-to-end model execution from
+a terminal:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/codex/main.cml \
+  --skills examples/codex/skills \
+  --input-json '"Ada"' \
+  --provider codex \
+  --model gpt-5.4-mini \
+  --reasoning low \
+  --sandbox read-only
+```
+
+Use JSON-RPC host mode when a non-Pi tool wants to own effect execution:
+
+```sh
+opam exec -- dune exec camlflow -- serve --stdio
+```
+
+Use the Pi SDK harness when host TypeScript wants a Flue-like agent API with
+sandbox selection, sessions, skills, shell commands, and workflow runs:
+
+```ts
+const harness = createPiCamlFlowHarness({ runtime });
+const agent = await harness.init({ sandbox: "workspace-write" });
+const session = await agent.session("triage");
+```
+
+The maintained Pi integration guide is
+[`pi-sdk-harness.md`](./pi-sdk-harness.md).
+
+## Smallest Workflow
+
+Create `main.cml`:
+
+```ocaml
+agent greeter : name:string -> string = Agent.bind "greeter"
+
+let main (name : string) : string =
+  let* greeting = greeter ~name:name in
+  greeting ^ "!"
+```
+
+Check and run it:
+
+```sh
+opam exec -- dune exec camlflow -- check main.cml
+opam exec -- dune exec camlflow -- run main.cml --input-json '"Ada"'
+```
+
+`let` binds pure values. `let*` sequences an effectful agent or skill call and
+waits for the host/provider/Pi worker to return typed JSON.
+
+With the default deterministic runtime, unresolved agents and skills return
+placeholder values. That is useful for parser, typing, and orchestration checks,
+but not for model quality evaluation.
+
+## Types And JSON
+
+CamlFlow supports primitives, records, variants, options, tuples, lists, pattern
+matching, recursion, and labeled calls.
+
+Example record and variant types:
+
+```ocaml
+type language = Python | TypeScript | OCaml
+
+type request = {
+  problem_name : string;
+  language : language;
+  must_cover : string list;
+}
+```
+
+JSON input uses explicit typed encodings:
+
+- records are JSON objects
+- lists are JSON arrays
+- variants are tagged objects
+- options are tagged variants, not implicit `null`
+
+Example input:
+
+```json
+{
+  "problem_name": "two sum",
+  "language": { "tag": "Python" },
+  "must_cover": ["hash map approach", "time complexity"]
+}
+```
+
+Constructors with payloads use `value`:
+
+```json
+{ "tag": "Some", "value": "extra context" }
+```
+
+For a larger reference, compare
+[`examples/problem-coach/types.cml`](../examples/problem-coach/types.cml) with
+[`examples/problem-coach/input.json`](../examples/problem-coach/input.json).
+For the full JSON encoding reference, including unit, tuples, multi-payload
+variants, options, and common decode failures, see
+[`json-encoding.md`](./json-encoding.md).
+For a runnable learning path across the examples directory, see
+[`examples/README.md`](../examples/README.md).
+
+## Agents
+
+Use `Agent.bind` when the implementation is supplied by the runtime provider,
+JSON-RPC host, or Pi worker:
+
+```ocaml
+agent draft_solver : request:normalized_request -> draft_solution =
+  Agent.bind "draft-solver"
+```
+
+Use `Agent.define` when the workflow itself should carry host-visible agent
+metadata:
+
+```ocaml
+agent answer_packager :
+  request:normalized_request -> draft:draft_solution -> solution_pack =
+  Agent.define
+    ~name:"problem-coach-packager"
+    ~style:"practical"
+    ~system_prompt:"Turn an algorithm draft into a user-facing answer pack."
+```
+
+Inline `~model:"..."` wins over CLI `--model` in provider-backed runs.
+Unsupported inline settings, such as `~temperature` in current direct CLI
+providers, fail fast instead of being silently ignored.
+
+## Skills
+
+Use `Skill.bind` for a named skill:
+
+```ocaml
+skill caveman : prompt:string -> string = Skill.bind "caveman"
+
+let main (prompt : string) : string =
+  let* answer = caveman ~prompt:prompt in
+  answer
+```
+
+For local prompt-backed skills, create:
+
+```text
+skills/
+  caveman/
+    SKILL.md
+```
+
+Run with:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/local-skill/main.cml \
+  --skills examples/local-skill/skills \
+  --input-json '"hello"'
+```
+
+Provider and host runs include the `SKILL.md` text in the effect metadata. The
+Pi harness also exposes `session.skill(name, { args })`, which validates Pi
+skill names before creating a `/skill:name` prompt.
+
+## Modules And Project Layout
+
+CamlFlow module resolution lowercases module paths and searches the project file
+plus include paths. A common layout is:
+
+```text
+my-flow/
+  camlflow.json
+  main.cml
+  types.cml
+  helpers.cml
+  skills/
+    triage/
+      SKILL.md
+```
+
+Use `open Types` for unqualified names or qualified module paths directly:
+
+```ocaml
+open Types
+
+let main (name : string) : Helpers.payload =
+  Helpers.make name
+```
+
+CamlFlow is not full OCaml. Do not rely on arbitrary OCaml stdlib or
+module-qualified calls such as `List.map` inside `.cml`; only loaded `.cml`
+modules resolve.
+
+## Project Defaults
+
+`camlflow.json` lets a project omit repeated CLI flags:
+
+```json
+{
+  "program": "main.cml",
+  "entry": "main",
+  "includePaths": ["."],
+  "skillsDir": "skills",
+  "provider": "codex",
+  "model": "gpt-5.4-mini",
+  "reasoning": "low",
+  "sandbox": "workspace-write"
+}
+```
+
+From that directory:
+
+```sh
+opam exec -- dune exec camlflow -- check
+opam exec -- dune exec camlflow -- run --input input.json
+```
+
+Precedence is explicit CLI flags, then nearest `camlflow.json`, then built-in
+defaults. Relative `program`, `includePaths`, `skillsDir`, and `allowWriteDirs`
+paths resolve from the config file's directory.
+For the full field reference, see
+[`project-config.md`](./project-config.md).
+
+## CLI Authoring Loop
+
+Use this loop while authoring:
+
+```sh
+opam exec -- dune exec camlflow -- parse main.cml
+opam exec -- dune exec camlflow -- check main.cml
+opam exec -- dune exec camlflow -- compile main.cml -o /tmp/main.ir.json
+opam exec -- dune exec camlflow -- run /tmp/main.ir.json --input input.json
+```
+
+Use `--input-json` for small values and `--input` for structured payloads:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/problem-coach/main.cml \
+  --skills examples/problem-coach/skills \
+  --input examples/problem-coach/input.json
+```
+
+Compiled IR and source runs use the same runtime and provider plumbing. The IR
+artifact is useful when a host wants to inspect or cache the typed workflow
+shape.
+
+## Provider-Backed CLI Runs
+
+Provider-backed runs are the quickest way to run effectful workflows without
+writing host code.
+
+Supported provider names:
+
+- `codex`
+- `opencode`
+- `claude-code`
+- `claude-cli`
+
+Provider runs still validate every returned JSON value against the declared
+CamlFlow type. If the provider returns malformed JSON or the wrong shape, the
+effect fails and the enclosing workflow fails.
+
+Use `--trace-provider` while debugging:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/codex/main.cml \
+  --skills examples/codex/skills \
+  --input-json '"Ada"' \
+  --provider codex \
+  --model gpt-5.4-mini \
+  --trace-provider
+```
+
+Provider sandbox modes are CLI-provider sandbox modes:
+`read-only`, `workspace-write`, and `danger-full-access`. These are separate
+from the Pi SDK harness sandbox presets.
+
+See [`provider-execution.md`](./provider-execution.md) for provider preflight
+and provider-specific behavior.
+For a compact flag list, see [`cli-reference.md`](./cli-reference.md).
+
+## JSON-RPC Host Runs
+
+Use JSON-RPC when another process owns effect execution. Start one server process
+per active run:
+
+```sh
+opam exec -- dune exec camlflow -- serve --stdio
+```
+
+Host flow:
+
+1. start `camlflow serve --stdio`
+2. send `initialize`
+3. send `camlflow/run`
+4. answer each `camlflow/executeEffect` request with typed JSON
+5. read the final `camlflow/run` result
+
+The bridge is JSON-RPC 2.0 over stdio with `Content-Length` framing. It is
+single-active-run by design.
+
+Use the TypeScript SDK instead of hand-rolling framing when possible:
+[`packages/camlflow-ts-json-rpc-sdk`](../packages/camlflow-ts-json-rpc-sdk).
+
+## Pi SDK Flue-Style Harness
+
+Use `packages/camlflow-pi-sdk` when integrating inside Pi or another TypeScript
+host that can provide Pi runtime services.
+
+Install in the host project:
+
+```sh
+npm install camlflow-pi-sdk camlflow-ts-json-rpc-sdk @mariozechner/pi-coding-agent
+```
+
+Minimal harness shape:
+
+```ts
+import { createPiCamlFlowHarness } from "camlflow-pi-sdk";
+
+const harness = createPiCamlFlowHarness({ runtime });
+const agent = await harness.init({
+  id: "repo-triage",
+  sandbox: "workspace-write",
+  model: runtime.session.model,
+});
+
+const session = await agent.session("issue-42");
+
+try {
+  const findings = await session.task("Inspect this checkout and list risk areas.", {
+    result: "json",
+  });
+
+  const triage = await session.skill("triage", {
+    args: { issueNumber: 42, findings },
+    result: "json",
+  });
+
+  const workflow = await agent.runWorkflow({
+    workflowPath: "examples/repo-triage/main.cml",
+    skillsDir: "examples/repo-triage/skills",
+    input: {
+      task: "Triage the current repository.",
+      suspected_area: "Pi harness integration",
+      file_hints: [],
+      goals: ["ground findings in repository evidence"],
+      constraints: ["keep the result actionable"],
+      mode: { tag: "Quick" },
+    },
+  });
+
+  console.log(triage, workflow.output);
+} finally {
+  await session.close();
+  await agent.close();
+}
+```
+
+Harness sandbox presets:
+
+- `local` / `workspace-write`: Pi coding tools plus trusted host shell
+- `read-only`: Pi read/search/list tools; no trusted shell
+- `ephemeral`: temporary workspace cleaned up when the agent closes
+- custom config or factory: host-owned `cwd`, tools, shell, and cleanup
+
+`session.shell(...)` is trusted host code, not a model-visible prompt. Use it
+for explicit commands and secret-bearing environment variables. The built-in
+local shell constrains `cwd` to the sandbox root, including symlink-aware checks.
+
+Important lifecycle rules:
+
+- one initialized agent owns one sandbox
+- sessions share the agent sandbox
+- `session.close()` closes only that Pi conversation
+- `agent.close()` cancels active workflow runs and releases the sandbox
+- prompt and skill calls are serial per session
+- use another session or `session.task(...)` for independent concurrent work
+
+See [`packages/camlflow-pi-sdk/README.md`](../packages/camlflow-pi-sdk/README.md)
+and
+[`packages/camlflow-pi-sdk/examples/flue-style-harness.ts`](../packages/camlflow-pi-sdk/examples/flue-style-harness.ts).
+For the host/session/sandbox decision guide, see
+[`pi-sdk-harness.md`](./pi-sdk-harness.md).
+
+## Choosing Boundaries
+
+Keep these boundaries in mind:
+
+- Put deterministic branching, type declarations, and output shape in `.cml`.
+- Put provider/model credentials outside `.cml`.
+- Put file-system write policy and shell commands in the host or Pi harness.
+- Use local `SKILL.md` files for reusable prompt behavior.
+- Use inline `Agent.define` metadata only when that metadata belongs to the
+  workflow contract.
+- Keep JSON inputs explicit; avoid relying on host-side coercion.
+
+## Common Failures
+
+`unbound module` or missing qualified name:
+Check include paths, lowercase module resolution, and whether the file is part
+of the project or `camlflow.json` include paths.
+
+`expected JSON value for type ...`:
+Check the input encoding. Variants and options must use `{ "tag": ... }`, with
+`value` when the constructor carries a payload.
+
+Provider returns invalid output:
+The provider must return JSON matching the declared return type. Re-run with
+`--trace-provider` and inspect the effect name, declared return type, and schema.
+
+`check`, `compile`, or `run` picked the wrong file:
+You may be under a different nearest `camlflow.json`. Reproduce with an explicit
+file path or record the current working directory.
+
+Pi harness shell cannot access a path:
+Check the selected harness sandbox. Built-in local shell commands cannot escape
+the sandbox root, even through symlinks.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,194 @@
+# CamlFlow Examples
+
+This directory is the quickest way to learn CamlFlow by running real workflows.
+Start with pure examples, then add skills, providers, JSON-RPC hosts, and the
+Pi SDK harness.
+
+Run commands from the repository root unless a section says otherwise. If your
+active opam switch is not OCaml 5.4, replace `opam exec --` with
+`opam exec --switch 5.4.0 --`.
+
+## Learning Path
+
+1. [`first-workflow`](./first-workflow): copyable tutorial project with input
+   JSON and `camlflow.json`.
+2. [`basic`](./basic): smallest `Agent.bind` workflow and `let*`.
+3. [`recursion`](./recursion): pure recursion without effects.
+4. [`variants-match`](./variants-match): variants and `match`.
+5. [`qualified-imports`](./qualified-imports): module loading and qualified
+   references.
+6. [`local-skill`](./local-skill): `Skill.bind` plus local `SKILL.md`.
+7. [`project-config`](./project-config): nearest `camlflow.json` defaults.
+8. [`problem-coach`](./problem-coach): practical structured-output workflow.
+9. [`repo-triage`](./repo-triage): repository-grounded workflow suited for a
+   Pi-style coding agent host.
+
+## Small Syntax Examples
+
+Run these first:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/first-workflow/main.cml \
+  --input examples/first-workflow/input.json
+opam exec -- dune exec camlflow -- run examples/basic/main.cml --input-json '"Ada"'
+opam exec -- dune exec camlflow -- run examples/recursion/main.cml --input-json '4'
+opam exec -- dune exec camlflow -- run examples/variants-match/main.cml
+opam exec -- dune exec camlflow -- check examples/qualified-imports/main.cml
+```
+
+These cover:
+
+- source file loading
+- simple JSON input
+- pure helpers
+- variants
+- pattern matching
+- module references
+
+## Skills
+
+[`local-skill`](./local-skill) shows the minimum local skill layout:
+
+```text
+skills/
+  caveman/
+    SKILL.md
+```
+
+Run it with:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/local-skill/main.cml \
+  --skills examples/local-skill/skills \
+  --input-json '"hello"'
+```
+
+## Project Defaults
+
+[`project-config`](./project-config) shows `camlflow.json`.
+
+```sh
+(cd examples/project-config && opam exec -- dune exec camlflow -- check)
+(cd examples/project-config && opam exec -- dune exec camlflow -- run --input input.json)
+```
+
+`check`, `compile`, and `run` can omit the file argument when the nearest
+`camlflow.json` supplies `program`.
+
+## Structured Workflow Examples
+
+Use these when you want examples closer to real host use:
+
+- [`problem-coach`](./problem-coach): algorithm-answer pack with typed record
+  output.
+- [`interview-pipeline`](./interview-pipeline): larger pipeline with records,
+  variants, options, lists, local skills, bound effects, and inline agents.
+- [`dev-workflow`](./dev-workflow): typed approval state machine for software
+  workflow planning and review.
+- [`repo-triage`](./repo-triage): repository investigation and triage report,
+  designed for a tool-using coding agent host.
+
+Run one deterministic structured workflow:
+
+```sh
+opam exec -- dune exec camlflow -- run examples/problem-coach/main.cml \
+  --skills examples/problem-coach/skills \
+  --input examples/problem-coach/input.json
+```
+
+Deterministic runs validate parsing, typing, module resolution, JSON decoding,
+effect wiring, and final output validation. They do not evaluate model quality.
+
+## Provider-Backed Examples
+
+[`codex`](./codex) exercises a bound agent, local prompt skill, and inline agent
+through the direct CLI provider path.
+
+```sh
+opam exec -- dune exec camlflow -- run examples/codex/main.cml \
+  --skills examples/codex/skills \
+  --input-json '"Ada"' \
+  --provider codex \
+  --model gpt-5.4-mini \
+  --reasoning low \
+  --sandbox read-only \
+  --trace-provider
+```
+
+Provider-backed runs are useful for terminal validation. Pi integrations should
+prefer `packages/camlflow-pi-sdk` instead of adding slash-command parsing here.
+
+## JSON-RPC Host Examples
+
+These examples show CamlFlow as a JSON-RPC server and a host process satisfying
+`camlflow/executeEffect` requests:
+
+- [`json-rpc-host`](./json-rpc-host): minimal dependency-free host.
+- [`json-rpc-problem-coach`](./json-rpc-problem-coach): structured host for the
+  `problem-coach` workflow.
+
+Run:
+
+```sh
+opam exec -- node examples/json-rpc-host/host.js
+opam exec -- node examples/json-rpc-problem-coach/host.js
+```
+
+Use one `camlflow serve --stdio` process per active run. The bridge is
+single-active-run by design.
+
+## Pi SDK Harness Examples
+
+The Pi SDK examples live under
+[`packages/camlflow-pi-sdk/examples`](../packages/camlflow-pi-sdk/examples).
+They are compile-checked TypeScript sketches for:
+
+- native Pi command/palette style workflow runs
+- cancellation and streamed output
+- Flue-style `agent.session(...).prompt/skill/task/shell` orchestration
+
+Run the package checks:
+
+```sh
+(cd packages/camlflow-pi-sdk && npm install && opam exec -- npm test)
+```
+
+The best `.cml` workflow to pair with a Pi-style coding agent is
+[`repo-triage`](./repo-triage), because it asks an agent to inspect the current
+repository and return grounded file-level findings.
+
+## JSON Input Cheat Sheet
+
+CamlFlow JSON uses explicit typed encodings:
+
+- `string`, `int`, `float`, `bool` map to JSON primitives.
+- records map to JSON objects.
+- lists map to JSON arrays.
+- nullary variants use `{ "tag": "Constructor" }`.
+- variants with payloads use `{ "tag": "Constructor", "value": ... }`.
+- options use the same variant encoding: `{ "tag": "None" }` or
+  `{ "tag": "Some", "value": ... }`.
+
+See [`problem-coach/input.json`](./problem-coach/input.json) and
+[`dev-workflow/input-approved.json`](./dev-workflow/input-approved.json) for
+concrete structured inputs.
+
+## More Docs
+
+- [Documentation map](../docs/README.md)
+- [First workflow tutorial](../docs/first-workflow.md)
+- [Language reference](../docs/language-reference.md)
+- [Glossary](../docs/glossary.md)
+- [Run modes](../docs/run-modes.md)
+- [Writing and running CamlFlow workflows](../docs/writing-and-running-camlflow.md)
+- [Workflow cookbook](../docs/workflow-cookbook.md)
+- [Install and run guide](../docs/how-to-run-and-install.md)
+- [CLI reference](../docs/cli-reference.md)
+- [Project config reference](../docs/project-config.md)
+- [JSON encoding reference](../docs/json-encoding.md)
+- [Editor support](../docs/editor-support.md)
+- [Pi SDK harness guide](../docs/pi-sdk-harness.md)
+- [Troubleshooting](../docs/troubleshooting.md)
+- [Provider-backed execution](../docs/provider-execution.md)
+- [JSON-RPC protocol](../docs/json-rpc.md)
+- [Pi SDK README](../packages/camlflow-pi-sdk/README.md)

--- a/examples/codex/README.md
+++ b/examples/codex/README.md
@@ -14,7 +14,7 @@ Files:
 Run:
 
 ```sh
-dune exec camlflow -- run examples/codex/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider codex \
@@ -26,7 +26,7 @@ dune exec camlflow -- run examples/codex/main.cml \
 Optional trace:
 
 ```sh
-dune exec camlflow -- run examples/codex/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider codex \
@@ -39,7 +39,7 @@ dune exec camlflow -- run examples/codex/main.cml \
 OpenCode variant:
 
 ```sh
-dune exec camlflow -- run examples/codex/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider opencode \
@@ -50,7 +50,7 @@ dune exec camlflow -- run examples/codex/main.cml \
 Claude Code variant:
 
 ```sh
-dune exec camlflow -- run examples/codex/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider claude-code \
@@ -61,7 +61,7 @@ dune exec camlflow -- run examples/codex/main.cml \
 Claude CLI variant:
 
 ```sh
-ANTHROPIC_API_KEY=... dune exec camlflow -- run examples/codex/main.cml \
+ANTHROPIC_API_KEY=... opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider claude-cli \

--- a/examples/codex/README.md
+++ b/examples/codex/README.md
@@ -14,7 +14,7 @@ Files:
 Run:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
+opam exec -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider codex \
@@ -26,7 +26,7 @@ opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
 Optional trace:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
+opam exec -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider codex \
@@ -39,7 +39,7 @@ opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
 OpenCode variant:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
+opam exec -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider opencode \
@@ -50,7 +50,7 @@ opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
 Claude Code variant:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
+opam exec -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider claude-code \
@@ -61,7 +61,7 @@ opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
 Claude CLI variant:
 
 ```sh
-ANTHROPIC_API_KEY=... opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/codex/main.cml \
+ANTHROPIC_API_KEY=... opam exec -- dune exec camlflow -- run examples/codex/main.cml \
   --skills examples/codex/skills \
   --input-json '"Ada"' \
   --provider claude-cli \

--- a/examples/dev-workflow/README.md
+++ b/examples/dev-workflow/README.md
@@ -27,7 +27,7 @@ Files:
 Approved path:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/dev-workflow/main.cml \
+opam exec -- dune exec camlflow -- run examples/dev-workflow/main.cml \
   --skills examples/dev-workflow/skills \
   --input examples/dev-workflow/input-approved.json
 ```
@@ -41,7 +41,7 @@ make run-dev-workflow
 Pending-approval path:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/dev-workflow/main.cml \
+opam exec -- dune exec camlflow -- run examples/dev-workflow/main.cml \
   --skills examples/dev-workflow/skills \
   --input examples/dev-workflow/input-pending.json
 ```
@@ -53,7 +53,7 @@ encoding, approval branching, and final report assembly.
 ## Provider-backed run
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/dev-workflow/main.cml \
+opam exec -- dune exec camlflow -- run examples/dev-workflow/main.cml \
   --skills examples/dev-workflow/skills \
   --input examples/dev-workflow/input-approved.json \
   --provider codex \

--- a/examples/dev-workflow/README.md
+++ b/examples/dev-workflow/README.md
@@ -27,7 +27,7 @@ Files:
 Approved path:
 
 ```sh
-dune exec ./bin/main.exe -- run examples/dev-workflow/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/dev-workflow/main.cml \
   --skills examples/dev-workflow/skills \
   --input examples/dev-workflow/input-approved.json
 ```
@@ -41,7 +41,7 @@ make run-dev-workflow
 Pending-approval path:
 
 ```sh
-dune exec ./bin/main.exe -- run examples/dev-workflow/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/dev-workflow/main.cml \
   --skills examples/dev-workflow/skills \
   --input examples/dev-workflow/input-pending.json
 ```
@@ -53,7 +53,7 @@ encoding, approval branching, and final report assembly.
 ## Provider-backed run
 
 ```sh
-dune exec ./bin/main.exe -- run examples/dev-workflow/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/dev-workflow/main.cml \
   --skills examples/dev-workflow/skills \
   --input examples/dev-workflow/input-approved.json \
   --provider codex \

--- a/examples/first-workflow/README.md
+++ b/examples/first-workflow/README.md
@@ -1,0 +1,46 @@
+# First Workflow Example
+
+This directory is the checked-in companion to
+[`../../docs/first-workflow.md`](../../docs/first-workflow.md). It shows the
+smallest project shape that combines:
+
+- a typed record input
+- one bound agent effect
+- `let*` effect sequencing
+- project-local `camlflow.json`
+- JSON input supplied at run time
+
+The deterministic runtime returns placeholder JSON for unresolved effects, so
+this example validates workflow wiring rather than model quality.
+
+From the repository root:
+
+```sh
+opam exec --switch 5.4.0 -- dune exec camlflow -- check examples/first-workflow/main.cml
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/first-workflow/main.cml \
+  --input examples/first-workflow/input.json
+```
+
+Expected deterministic output:
+
+```text
+steps: 1
+"!"
+```
+
+From this directory, use the project config:
+
+```sh
+opam exec --switch 5.4.0 -- dune exec camlflow -- check
+opam exec --switch 5.4.0 -- dune exec camlflow -- run --input input.json
+```
+
+`camlflow.json` supplies the program and entrypoint. Input payloads still come
+from `--input` or `--input-json`; project config does not store input paths.
+
+Continue with:
+
+- [First workflow tutorial](../../docs/first-workflow.md)
+- [Language reference](../../docs/language-reference.md)
+- [JSON encoding](../../docs/json-encoding.md)
+- [Project config](../../docs/project-config.md)

--- a/examples/first-workflow/README.md
+++ b/examples/first-workflow/README.md
@@ -16,8 +16,8 @@ this example validates workflow wiring rather than model quality.
 From the repository root:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- check examples/first-workflow/main.cml
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/first-workflow/main.cml \
+opam exec -- dune exec camlflow -- check examples/first-workflow/main.cml
+opam exec -- dune exec camlflow -- run examples/first-workflow/main.cml \
   --input examples/first-workflow/input.json
 ```
 
@@ -31,8 +31,8 @@ steps: 1
 From this directory, use the project config:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- check
-opam exec --switch 5.4.0 -- dune exec camlflow -- run --input input.json
+opam exec -- dune exec camlflow -- check
+opam exec -- dune exec camlflow -- run --input input.json
 ```
 
 `camlflow.json` supplies the program and entrypoint. Input payloads still come

--- a/examples/first-workflow/camlflow.json
+++ b/examples/first-workflow/camlflow.json
@@ -1,0 +1,4 @@
+{
+  "program": "main.cml",
+  "entry": "main"
+}

--- a/examples/first-workflow/input.json
+++ b/examples/first-workflow/input.json
@@ -1,0 +1,4 @@
+{
+  "name": "Ada",
+  "punctuation": "!"
+}

--- a/examples/first-workflow/main.cml
+++ b/examples/first-workflow/main.cml
@@ -1,0 +1,10 @@
+type request = {
+  name : string;
+  punctuation : string;
+}
+
+agent greeter : name:string -> string = Agent.bind "greeter"
+
+let main (request : request) : string =
+  let* greeting = greeter ~name:request.name in
+  greeting ^ request.punctuation

--- a/examples/interview-pipeline/README.md
+++ b/examples/interview-pipeline/README.md
@@ -31,7 +31,7 @@ This works without any provider and is useful to verify parsing, typing, module
 resolution, JSON encoding, and deterministic runtime defaults.
 
 ```sh
-dune exec camlflow -- run examples/interview-pipeline/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/interview-pipeline/main.cml \
   --skills examples/interview-pipeline/skills \
   --input examples/interview-pipeline/input.json
 ```
@@ -39,7 +39,7 @@ dune exec camlflow -- run examples/interview-pipeline/main.cml \
 ## Codex-backed run
 
 ```sh
-dune exec camlflow -- run examples/interview-pipeline/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/interview-pipeline/main.cml \
   --skills examples/interview-pipeline/skills \
   --input examples/interview-pipeline/input.json \
   --provider codex \
@@ -51,7 +51,7 @@ dune exec camlflow -- run examples/interview-pipeline/main.cml \
 Optional trace:
 
 ```sh
-dune exec camlflow -- run examples/interview-pipeline/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/interview-pipeline/main.cml \
   --skills examples/interview-pipeline/skills \
   --input examples/interview-pipeline/input.json \
   --provider codex \

--- a/examples/interview-pipeline/README.md
+++ b/examples/interview-pipeline/README.md
@@ -31,7 +31,7 @@ This works without any provider and is useful to verify parsing, typing, module
 resolution, JSON encoding, and deterministic runtime defaults.
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/interview-pipeline/main.cml \
+opam exec -- dune exec camlflow -- run examples/interview-pipeline/main.cml \
   --skills examples/interview-pipeline/skills \
   --input examples/interview-pipeline/input.json
 ```
@@ -39,7 +39,7 @@ opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/interview-pipelin
 ## Codex-backed run
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/interview-pipeline/main.cml \
+opam exec -- dune exec camlflow -- run examples/interview-pipeline/main.cml \
   --skills examples/interview-pipeline/skills \
   --input examples/interview-pipeline/input.json \
   --provider codex \
@@ -51,7 +51,7 @@ opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/interview-pipelin
 Optional trace:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/interview-pipeline/main.cml \
+opam exec -- dune exec camlflow -- run examples/interview-pipeline/main.cml \
   --skills examples/interview-pipeline/skills \
   --input examples/interview-pipeline/input.json \
   --provider codex \

--- a/examples/model-response-retry/README.md
+++ b/examples/model-response-retry/README.md
@@ -24,7 +24,7 @@ That forces the recursive retry path until the example exhausts its max
 attempts.
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/model-response-retry/main.cml \
+opam exec -- dune exec camlflow -- run examples/model-response-retry/main.cml \
   --input-json '"let x = 1"'
 ```
 
@@ -58,7 +58,7 @@ The workflow validates that response with `needs_retry`, derives retry text with
 `unwrap_or`, and uses a recursive helper today instead of `for` / `while`.
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/model-response-retry/main.cml \
+opam exec -- dune exec camlflow -- run examples/model-response-retry/main.cml \
   --input-json '"let x = 1"' \
   --provider codex \
   --model gpt-5.4-mini \

--- a/examples/model-response-retry/README.md
+++ b/examples/model-response-retry/README.md
@@ -24,7 +24,7 @@ That forces the recursive retry path until the example exhausts its max
 attempts.
 
 ```sh
-dune exec ./bin/main.exe -- run examples/model-response-retry/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/model-response-retry/main.cml \
   --input-json '"let x = 1"'
 ```
 
@@ -58,7 +58,7 @@ The workflow validates that response with `needs_retry`, derives retry text with
 `unwrap_or`, and uses a recursive helper today instead of `for` / `while`.
 
 ```sh
-dune exec ./bin/main.exe -- run examples/model-response-retry/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/model-response-retry/main.cml \
   --input-json '"let x = 1"' \
   --provider codex \
   --model gpt-5.4-mini \

--- a/examples/model-response-validation/README.md
+++ b/examples/model-response-validation/README.md
@@ -20,7 +20,7 @@ declared `code_response` shape, so the example still proves parsing, typing,
 JSON decoding, and typed branching over the response object.
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/model-response-validation/main.cml \
+opam exec -- dune exec camlflow -- run examples/model-response-validation/main.cml \
   --input-json '"let x = 1"'
 ```
 
@@ -57,7 +57,7 @@ The workflow then branches on `response.accuracy` and `response.action`.
 Example:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/model-response-validation/main.cml \
+opam exec -- dune exec camlflow -- run examples/model-response-validation/main.cml \
   --input-json '"let x = 1"' \
   --provider codex \
   --model gpt-5.4-mini \

--- a/examples/model-response-validation/README.md
+++ b/examples/model-response-validation/README.md
@@ -20,7 +20,7 @@ declared `code_response` shape, so the example still proves parsing, typing,
 JSON decoding, and typed branching over the response object.
 
 ```sh
-dune exec ./bin/main.exe -- run examples/model-response-validation/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/model-response-validation/main.cml \
   --input-json '"let x = 1"'
 ```
 
@@ -57,7 +57,7 @@ The workflow then branches on `response.accuracy` and `response.action`.
 Example:
 
 ```sh
-dune exec ./bin/main.exe -- run examples/model-response-validation/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/model-response-validation/main.cml \
   --input-json '"let x = 1"' \
   --provider codex \
   --model gpt-5.4-mini \

--- a/examples/problem-coach/README.md
+++ b/examples/problem-coach/README.md
@@ -34,7 +34,7 @@ Files:
 ## Deterministic local run
 
 ```sh
-dune exec camlflow -- run examples/problem-coach/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/problem-coach/main.cml \
   --skills examples/problem-coach/skills \
   --input examples/problem-coach/input.json
 ```
@@ -42,7 +42,7 @@ dune exec camlflow -- run examples/problem-coach/main.cml \
 ## Codex-backed run
 
 ```sh
-dune exec camlflow -- run examples/problem-coach/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/problem-coach/main.cml \
   --skills examples/problem-coach/skills \
   --input examples/problem-coach/input.json \
   --provider codex \

--- a/examples/problem-coach/README.md
+++ b/examples/problem-coach/README.md
@@ -34,7 +34,7 @@ Files:
 ## Deterministic local run
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/problem-coach/main.cml \
+opam exec -- dune exec camlflow -- run examples/problem-coach/main.cml \
   --skills examples/problem-coach/skills \
   --input examples/problem-coach/input.json
 ```
@@ -42,7 +42,7 @@ opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/problem-coach/mai
 ## Codex-backed run
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/problem-coach/main.cml \
+opam exec -- dune exec camlflow -- run examples/problem-coach/main.cml \
   --skills examples/problem-coach/skills \
   --input examples/problem-coach/input.json \
   --provider codex \

--- a/examples/project-config/README.md
+++ b/examples/project-config/README.md
@@ -4,16 +4,19 @@ This example shows project-local `camlflow.json` defaults in the smallest
 possible setup. The config pins the program path and entrypoint, so `run`,
 `check`, and `compile` can all omit the file argument.
 
+For the full config field reference, see
+[`../../docs/project-config.md`](../../docs/project-config.md).
+
 From this directory:
 
 ```sh
-dune exec camlflow -- check
-dune exec camlflow -- run --input input.json
-dune exec camlflow -- compile -o /tmp/project-config.ir.json
+opam exec --switch 5.4.0 -- dune exec camlflow -- check
+opam exec --switch 5.4.0 -- dune exec camlflow -- run --input input.json
+opam exec --switch 5.4.0 -- dune exec camlflow -- compile -o /tmp/project-config.ir.json
 ```
 
 From the repo root:
 
 ```sh
-(cd examples/project-config && dune exec camlflow -- run --input input.json)
+(cd examples/project-config && opam exec --switch 5.4.0 -- dune exec camlflow -- run --input input.json)
 ```

--- a/examples/project-config/README.md
+++ b/examples/project-config/README.md
@@ -10,13 +10,13 @@ For the full config field reference, see
 From this directory:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- check
-opam exec --switch 5.4.0 -- dune exec camlflow -- run --input input.json
-opam exec --switch 5.4.0 -- dune exec camlflow -- compile -o /tmp/project-config.ir.json
+opam exec -- dune exec camlflow -- check
+opam exec -- dune exec camlflow -- run --input input.json
+opam exec -- dune exec camlflow -- compile -o /tmp/project-config.ir.json
 ```
 
 From the repo root:
 
 ```sh
-(cd examples/project-config && opam exec --switch 5.4.0 -- dune exec camlflow -- run --input input.json)
+(cd examples/project-config && opam exec -- dune exec camlflow -- run --input input.json)
 ```

--- a/examples/provider-hooks/README.md
+++ b/examples/provider-hooks/README.md
@@ -12,5 +12,5 @@ Files:
 Run:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec examples/provider-hooks/host.exe
+opam exec -- dune exec examples/provider-hooks/host.exe
 ```

--- a/examples/provider-hooks/README.md
+++ b/examples/provider-hooks/README.md
@@ -12,5 +12,5 @@ Files:
 Run:
 
 ```sh
-dune exec examples/provider-hooks/host.exe
+opam exec --switch 5.4.0 -- dune exec examples/provider-hooks/host.exe
 ```

--- a/examples/repo-triage/README.md
+++ b/examples/repo-triage/README.md
@@ -24,13 +24,56 @@ Files:
 
 ## Deterministic local run
 
-This validates parsing, typing, module resolution, JSON encoding, and effect wiring, but the result will use deterministic placeholder effect behavior unless you run through a real host.
+This validates parsing, typing, module resolution, JSON encoding, and effect
+wiring. It does not inspect the repository or call a model. Without a provider,
+JSON-RPC host, or Pi worker, CamlFlow uses deterministic placeholder effect
+behavior.
 
 ```sh
-dune exec camlflow -- run examples/repo-triage/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/repo-triage/main.cml \
   --skills examples/repo-triage/skills \
   --input examples/repo-triage/input.json
 ```
+
+Expected deterministic output is structurally valid but empty:
+
+```text
+steps: 4
+{
+  "title": "",
+  "summary": "",
+  "relevant_files": [],
+  "findings": [],
+  "root_causes": [],
+  "patch_plan": [],
+  "validation_steps": [],
+  "follow_up_questions": []
+}
+```
+
+That output means the workflow contract is valid and all four effect boundaries
+were reached. It is not a meaningful triage report.
+
+## Meaningful host or provider run
+
+To get repository-grounded findings, run this workflow through a host that can
+inspect files, such as the Pi SDK harness or the historical `pi-mono` prototype.
+For a direct terminal smoke, use a configured provider:
+
+```sh
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/repo-triage/main.cml \
+  --skills examples/repo-triage/skills \
+  --input examples/repo-triage/input.json \
+  --provider codex \
+  --model gpt-5.4-mini \
+  --reasoning low \
+  --sandbox workspace-write \
+  --trace-provider
+```
+
+Provider runs require the provider CLI and credentials to be configured outside
+CamlFlow. The best Pi path is `packages/camlflow-pi-sdk`, where host code can
+call `agent.runWorkflow(...)` inside a selected sandbox.
 
 ## `pi-mono` host run
 

--- a/examples/repo-triage/README.md
+++ b/examples/repo-triage/README.md
@@ -30,7 +30,7 @@ JSON-RPC host, or Pi worker, CamlFlow uses deterministic placeholder effect
 behavior.
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/repo-triage/main.cml \
+opam exec -- dune exec camlflow -- run examples/repo-triage/main.cml \
   --skills examples/repo-triage/skills \
   --input examples/repo-triage/input.json
 ```
@@ -61,7 +61,7 @@ inspect files, such as the Pi SDK harness or the historical `pi-mono` prototype.
 For a direct terminal smoke, use a configured provider:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/repo-triage/main.cml \
+opam exec -- dune exec camlflow -- run examples/repo-triage/main.cml \
   --skills examples/repo-triage/skills \
   --input examples/repo-triage/input.json \
   --provider codex \

--- a/examples/swe-leetcode/README.md
+++ b/examples/swe-leetcode/README.md
@@ -17,7 +17,7 @@ Files:
 Run:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/swe-leetcode/main.cml \
+opam exec -- dune exec camlflow -- run examples/swe-leetcode/main.cml \
   --skills examples/swe-leetcode/skills \
   --input-json '"two sum"' \
   --provider codex \
@@ -27,7 +27,7 @@ opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/swe-leetcode/main
 Optional trace:
 
 ```sh
-opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/swe-leetcode/main.cml \
+opam exec -- dune exec camlflow -- run examples/swe-leetcode/main.cml \
   --skills examples/swe-leetcode/skills \
   --input-json '"binary search"' \
   --provider codex \

--- a/examples/swe-leetcode/README.md
+++ b/examples/swe-leetcode/README.md
@@ -17,7 +17,7 @@ Files:
 Run:
 
 ```sh
-dune exec camlflow -- run examples/swe-leetcode/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/swe-leetcode/main.cml \
   --skills examples/swe-leetcode/skills \
   --input-json '"two sum"' \
   --provider codex \
@@ -27,7 +27,7 @@ dune exec camlflow -- run examples/swe-leetcode/main.cml \
 Optional trace:
 
 ```sh
-dune exec camlflow -- run examples/swe-leetcode/main.cml \
+opam exec --switch 5.4.0 -- dune exec camlflow -- run examples/swe-leetcode/main.cml \
   --skills examples/swe-leetcode/skills \
   --input-json '"binary search"' \
   --provider codex \

--- a/packages/camlflow-pi-sdk/README.md
+++ b/packages/camlflow-pi-sdk/README.md
@@ -26,6 +26,16 @@ runtime separate from trusted host orchestration code.
 See
 [`docs/adr/0001-programmatic-camlflow-pi-sdk.md`](../../docs/adr/0001-programmatic-camlflow-pi-sdk.md)
 for the integration boundary decision.
+For the CamlFlow authoring path before you embed workflows in Pi, see
+[`docs/writing-and-running-camlflow.md`](../../docs/writing-and-running-camlflow.md).
+For the supported `.cml` syntax surface, see
+[`docs/language-reference.md`](../../docs/language-reference.md).
+For shared CamlFlow/Pi terminology, see
+[`docs/glossary.md`](../../docs/glossary.md).
+For the JSON shapes Pi workers must return for typed workflow effects, see
+[`docs/json-encoding.md`](../../docs/json-encoding.md).
+For a focused host-session vs Flue-style harness guide, see
+[`docs/pi-sdk-harness.md`](../../docs/pi-sdk-harness.md).
 
 ## Install
 
@@ -38,9 +48,11 @@ exact Pi SDK version.
 
 ## Usage
 
-For complete, compile-checked host-side examples, see
+For complete, compile-checked host-side examples and guidance on choosing
+between a workflow host session and the Flue-style harness, see
 [`examples/`](./examples). The examples cover a native Pi command or palette
-action, streamed worker output, and user cancellation.
+action, streamed worker output, user cancellation, and sandbox-aware agent
+orchestration.
 
 ```ts
 import { createPiCamlFlowHostSession } from "camlflow-pi-sdk";
@@ -172,7 +184,7 @@ try {
 
   await session.shell("git add -A && git commit --file -", {
     stdin: `fix: ${summary}`,
-    env: { GITHUB_TOKEN: process.env.GITHUB_TOKEN },
+    env: { GITHUB_TOKEN: process.env.GITHUB_TOKEN ?? "" },
   });
 
   const workflow = await agent.runWorkflow({

--- a/packages/camlflow-pi-sdk/examples/README.md
+++ b/packages/camlflow-pi-sdk/examples/README.md
@@ -5,6 +5,9 @@ Pi adapter. They are compile-checked integration sketches rather than
 standalone CLIs: a real Pi command, palette action, or panel supplies the
 `PiCamlFlowRuntime` from its active Pi session.
 
+For the maintained host-session vs Flue-style harness guide, see
+[`docs/pi-sdk-harness.md`](../../../docs/pi-sdk-harness.md).
+
 ## Setup
 
 From `packages/camlflow-pi-sdk/`:
@@ -18,6 +21,24 @@ The build compiles the SDK first and then compiles these examples against the
 generated `dist/` declarations.
 
 ## Examples
+
+### Which API Should I Start With?
+
+Use `createPiCamlFlowHostSession(...)` when a Pi command, palette action, or
+panel already knows which `.cml` workflow it wants to run. This is the smallest
+embedding surface: one host session owns one JSON-RPC bridge process, forwards
+workflow progress into Pi UI, and maps CamlFlow effects onto Pi worker sessions.
+
+Use `createPiCamlFlowHarness(...)` when host code wants a Flue-style agent
+object first. The harness owns the sandbox, opens named Pi sessions, supports
+one-shot `task(...)` calls, invokes Pi skills, runs trusted shell commands, and
+can call CamlFlow workflows from the same agent runtime.
+
+| Goal | Start with |
+| --- | --- |
+| Add a "Run CamlFlow workflow" command to Pi | `command-runner.ts` |
+| Build a panel with cancel and streamed output state | `cancellation-and-streams.ts` |
+| Orchestrate sessions, skills, shell, and workflows like Flue | `flue-style-harness.ts` |
 
 ### Native command runner
 

--- a/packages/camlflow-ts-json-rpc-sdk/README.md
+++ b/packages/camlflow-ts-json-rpc-sdk/README.md
@@ -7,6 +7,17 @@ TypeScript SDK for the current CamlFlow JSON-RPC bridge implemented in:
 - `lib/rpc_server.ml`
 - `lib/effect_request.ml`
 
+If you are starting from `.cml` authoring rather than host integration code,
+read
+[`docs/writing-and-running-camlflow.md`](../../docs/writing-and-running-camlflow.md)
+first. For the supported `.cml` syntax surface, see
+[`docs/language-reference.md`](../../docs/language-reference.md). For shared
+host/runtime terminology, see
+[`docs/glossary.md`](../../docs/glossary.md). For the JSON shapes hosts must
+pass into `run(...)` and return from
+effect handlers, see
+[`docs/json-encoding.md`](../../docs/json-encoding.md).
+
 The SDK targets the bridge as it exists today:
 
 - JSON-RPC 2.0 over stdio

--- a/packages/camlflow-vscode/README.md
+++ b/packages/camlflow-vscode/README.md
@@ -12,6 +12,21 @@ This package contains VS Code support for CamlFlow:
 - semantic editor features from the LSP:
   diagnostics, hover, go-to-definition, references, rename, and document outline
 
+## Workflow Authoring Docs
+
+The extension handles editing, highlighting, LSP features, and
+`camlflow.json` validation. Use the main docs for language and runtime
+behavior:
+
+- [Docs map](../../docs/README.md)
+- [Language reference](../../docs/language-reference.md)
+- [Writing and running CamlFlow](../../docs/writing-and-running-camlflow.md)
+- [Workflow cookbook](../../docs/workflow-cookbook.md)
+- [`camlflow.json` project config](../../docs/project-config.md)
+- [JSON encoding reference](../../docs/json-encoding.md)
+- [Editor support](../../docs/editor-support.md)
+- [Troubleshooting](../../docs/troubleshooting.md)
+
 ## Layout
 
 - `language-configuration.json`: editor behavior for `.cml`

--- a/packages/camlflow-zed/README.md
+++ b/packages/camlflow-zed/README.md
@@ -14,6 +14,20 @@ The Zed extension expects a `camlflow` executable to be available on the worktre
 camlflow lsp
 ```
 
+## Workflow Authoring Docs
+
+The extension handles editing, LSP startup, and points Zed at the shared
+`camlflow.json` schema. Use the main docs for language and runtime behavior:
+
+- [Docs map](../../docs/README.md)
+- [Language reference](../../docs/language-reference.md)
+- [Writing and running CamlFlow](../../docs/writing-and-running-camlflow.md)
+- [Workflow cookbook](../../docs/workflow-cookbook.md)
+- [`camlflow.json` project config](../../docs/project-config.md)
+- [JSON encoding reference](../../docs/json-encoding.md)
+- [Editor support](../../docs/editor-support.md)
+- [Troubleshooting](../../docs/troubleshooting.md)
+
 ## Layout
 
 - `extension.toml`: Zed extension manifest


### PR DESCRIPTION
## Summary

- add a docs map plus authoring, first-workflow, language, cookbook, run-mode, CLI, project-config, JSON encoding, Pi harness, editor, troubleshooting, and validation guides
- add a checked-in `examples/first-workflow` companion project
- update existing README/example/SDK/editor docs to point at the new workflow and Pi harness guidance
- clarify Dune 3.22 switch usage and deterministic vs provider/host-backed example behavior

## Validation

- `git diff --check`
- scoped markdown link checker: 68 markdown files
- `opam exec --switch 5.4.0 -- dune --version` -> 3.22.2
- previously run in this docs loop: core deps, `dune fmt`, `dune test`, `dune build`, CLI help/basic run/serve smoke, docs command smokes, VS Code smoke, JSON-RPC SDK tests, Pi SDK tests

## Notes

- Zed `cargo check` remains blocked locally because `cargo` is not installed.
